### PR TITLE
Optimize stage1 code

### DIFF
--- a/builder-hex0-x86-stage1.hex0
+++ b/builder-hex0-x86-stage1.hex0
@@ -35,17 +35,21 @@
 # do that first. We far jump in order to set CS.
 # Use special encoding of "xor ax, ax" to appease some BIOSes.
 33 C0             # xor ax, ax
-EA 07 7C 00 00    # jmp far setcs
-#:setcs
 8E D8             # mov ds, ax
 8E C0             # mov es, ax
 8E D0             # mov ss, ax
 BC 00 77          # mov sp, 0x7700
 FC                # cld ; clear direction flag
+EA 11 7C 00 00    # jmp far compile
 
 #----------------------------------------
+#[7C11]
+#:compile
 # Compile hex0 to binary
-# compile(dl=boot_drive):
+#
+# input:
+# ecx = logical sector to read
+# dl  = boot drive
 
 # this flag is set after the first digit is seen
 31 DB             # xor bx,bx
@@ -53,14 +57,14 @@ FC                # cld ; clear direction flag
 BF 00 7E          # mov di, $stage2_entry
 
 #:read_loop
-E8 97 00          # call read
+E8 80 00          # call read
 84 C0             # test al, al
 74 4B             # jz finish
 
 3C 23             # cmp al, '#'
 74 28             # jz skip_comment
 
-3C 3B             # cmp ';'
+3C 3B             # cmp al, ';'
 74 24             # jz skip_comment
 
 3C 66             # cmp al, 'f'
@@ -96,7 +100,7 @@ EB 15             # jmp maybe_store
 EB 09             # jmp maybe_store
 
 #:skip_comment
-E8 64 00          # call read
+E8 4D 00          # call read
 3C 0A             # cmp al, '\n'
 75 F9             # jnz skip_comment
 EB C4             # jmp read_loop
@@ -125,28 +129,12 @@ EB AE             # jmp read_loop
 #:finish
 E9 95 01          # jmp stage2_entry
 
-#-------------
-# align to 16 bit boundary
-00 00 00 00 00
-#:addr_packet
-10 00
-#:num_sectors_bios
-01 00
-#:dest_offset
-00 78
-#:dest_segment
-00 00
-#:starting_lba
-01 00 00 00 00 00 00 00
-#:last_byte
-FF 01
-
 #------------------------------------------------------------
-#[7C82]
+#[7C6B]
 #:read_sector
 # input:
 # ecx = logical sector to read
-# dl = drive
+# dl  = drive
 #
 # returns: ecx - next logical sector to read from
 #
@@ -155,15 +143,15 @@ FF 01
 89 FB                   # mov bx, di      ; int 13 writes to bx
 
 #:read_one_loop
-66 89 0E 78 7C          # mov dword ptr [starting_lba], ecx
+66 89 0E C8 7C          # mov dword ptr [starting_lba], ecx
 BE 01 00                # mov si, 1
-89 36 72 7C             # mov word ptr [num_sectors_bios], si
+89 36 C2 7C             # mov word ptr [num_sectors_bios], si
 B4 42                   # mov ah, 0x42        ; rw mode = 42 (read LBA)
-BE 70 7C                # mov si, addr_packet      ; disk address packet
+BE C0 7C                # mov si, addr_packet      ; disk address packet
 CD 13                   # int 0x13
 72 0F                   # jc read_error
 
-8B 3E 72 7C             # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
+8B 3E C2 7C             # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
 85 FF                   # test di, di
 74 07                   # jz read_error
 
@@ -179,16 +167,13 @@ CD 13                   # int 0x13
 EB D6                   # jmp read_one_loop
 
 #----------------------------------------
-#[7CB0]
+#[7C99]
 #:read
 53                      # push bx
 51                      # push cx
-52                      # push dx
-56                      # push si
-57                      # push di
 
 # get current position
-BB 78 7C                # mov bx, starting_lba
+BB C8 7C                # mov bx, starting_lba
 66 8B 0F                # mov ecx, [bx]
 8B 47 08                # mov ax, [bx+8]
 
@@ -201,25 +186,35 @@ BB 78 7C                # mov bx, starting_lba
 EB 08                   # jmp getchar
 
 #:read_next_sector
-E8 B9 FF                # call read_sector
+E8 BC FF                # call read_sector
 # save new location and offset
 66 89 0F                # mov [bx], ecx
 31 C0                   # xor ax, ax
 
 #:getchar
 89 47 08                # mov [bx+8], ax
-BE 00 78                # mov si, 0x7800
 89 C3                   # mov bx, ax
-8A 00                   # mov al, [si+bx]
+8A 87 00 78             # mov al, [bx+0x7800]
 
 #finish:
-5F                      # pop di
-5E                      # pop si
-5A                      # pop dx
 59                      # pop cx
 5B                      # pop bx
 C3                      # ret
 
+#-------------
+# initialized data section
+#:addr_packet
+10 00
+#:num_sectors_bios
+01 00
+#:dest_offset
+00 78
+#:dest_segment
+00 00
+#:starting_lba
+01 00 00 00 00 00 00 00
+#:last_byte
+FF 01
 
 # padding to fill a 512 byte sector
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -235,7 +230,8 @@ C3                      # ret
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00
 
 # disk ID - some BIOSes don't tolerate zeros
 12 34 56 78

--- a/builder-hex0-x86-stage1.hex2
+++ b/builder-hex0-x86-stage1.hex2
@@ -35,17 +35,20 @@
 # do that first. We far jump in order to set CS.
 # Use special encoding of "xor ax, ax" to appease some BIOSes.
 33 C0             # xor ax, ax
-EA $setcs 00 00   # jmp far setcs
-:setcs
 8E D8             # mov ds, ax
 8E C0             # mov es, ax
 8E D0             # mov ss, ax
 BC 00 77          # mov sp, 0x7700
 FC                # cld ; clear direction flag
+EA $compile 00 00 # jmp far compile
 
 #----------------------------------------
+:compile
 # Compile hex0 to binary
-# compile(dl=boot_drive):
+#
+# input:
+# ecx = logical sector to read
+# dl  = boot drive
 
 # this flag is set after the first digit is seen
 31 DB             # xor bx,bx
@@ -60,7 +63,7 @@ E8 @read          # call read
 3C 23             # cmp al, '#'
 74 !skip_comment  # jz skip_comment
 
-3C 3B             # cmp ';'
+3C 3B             # cmp al, ';'
 74 !skip_comment  # jz skip_comment
 
 3C 66             # cmp al, 'f'
@@ -125,27 +128,11 @@ EB !read_loop     # jmp read_loop
 :finish
 E9 @stage2_entry  # jmp stage2_entry
 
-#-------------
-# align to 16 bit boundary
-00 00 00 00 00
-:addr_packet
-10 00
-:num_sectors_bios
-01 00
-:dest_offset
-00 78
-:dest_segment
-00 00
-:starting_lba
-01 00 00 00 00 00 00 00
-:last_byte
-FF 01
-
 #------------------------------------------------------------
 :read_sector
 # input:
 # ecx = logical sector to read
-# dl = drive
+# dl  = drive
 #
 # returns: ecx - next logical sector to read from
 #
@@ -181,9 +168,6 @@ EB !read_one_loop       # jmp read_one_loop
 :read
 53                      # push bx
 51                      # push cx
-52                      # push dx
-56                      # push si
-57                      # push di
 
 # get current position
 BB $starting_lba        # mov bx, starting_lba
@@ -206,18 +190,28 @@ E8 @read_sector         # call read_sector
 
 :getchar
 89 47 08                # mov [bx+8], ax
-BE 00 78                # mov si, 0x7800
 89 C3                   # mov bx, ax
-8A 00                   # mov al, [si+bx]
+8A 87 00 78             # mov al, [bx+0x7800]
 
 #finish:
-5F                      # pop di
-5E                      # pop si
-5A                      # pop dx
 59                      # pop cx
 5B                      # pop bx
 C3                      # ret
 
+#-------------
+# initialized data section
+:addr_packet
+10 00
+:num_sectors_bios
+01 00
+:dest_offset
+00 78
+:dest_segment
+00 00
+:starting_lba
+01 00 00 00 00 00 00 00
+:last_byte
+FF 01
 
 # padding to fill a 512 byte sector
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -233,7 +227,8 @@ C3                      # ret
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00
 
 # disk ID - some BIOSes don't tolerate zeros
 12 34 56 78


### PR DESCRIPTION
This saves 12 bytes of space (7 bytes of code + 5 bytes of padding), and cleanly separates the code and data portions of stage1. Stage1 now consists of 192 bytes of code, and 18 bytes of data, excluding the boilerplate necessary to make it a valid boot sector.