### PR TITLE
Add E820 memory map support

### DIFF
--- a/builder-hex0-x86-stage2.hex0
+++ b/builder-hex0-x86-stage2.hex0
@@ -96,7 +96,7 @@
 #                      0x100  0x100  current directory
 #                      0x200  x0E00  file descriptors 448 * 8 bytes each
 #                                    { global_file_index, current_offset }
-#    10800 -    1FFFF unused
+#    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
 #     A000 -     A1FF sector read buffer - 16bit
 #     7C00 -     8600 code
@@ -511,7 +511,7 @@ FB                      # sti
 1F                      # pop ds
 9D                      # popf
 
-A3 7E 80                # mov word ptr [Init_A20], ax
+A3 26 81                # mov word ptr [Init_A20], ax
 85 C0                   # test ax, ax
 75 05                   # jnz init_no_a20
 
@@ -520,25 +520,77 @@ B8 01 24                # mov ax,2401h     # enable A20 line
 CD 15                   # int 15h
 
 #:init_no_a20
-# start 32bit mode
-FA                      # cli
-0F 01 06 8E 7F              # sgdt Saved_GDT_locator
-EB 06                   # jmp past_MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
+
+# adapted from https://wiki.osdev.org/Detecting_Memory_(x86)#Getting_an_E820_Memory_Map
+# use the INT 0x15, eax=0xE820 BIOS function to get a memory map
+
+66 60                       # pushad
+66 9C                       # pushfd
+06                          # push es
+68 00 10                    # push 0x1000
+07                          # pop es
+EB 03                       # jmp past_MBR
+90                          # nop    ; padding to align MBR
 # This is the DOS/MBR identifier at offset 510:
 55 AA
 #:past_MBR
+66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
+26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
+BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
+66 31 ED                    # xor ebp, ebp              ; keep an entry count in bp
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; place "SMAP" into edx
+66 B8 20 E8 00 00           # mov eax, 0xE820
+26 66 C7 45 14 01 00 00 00  # mov dword ptr es:[di + 20], 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes
+CD 15                       # int 0x15
+72 65                       # jc short failed           ; carry set on first call means "unsupported function"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; Some BIOSes apparently trash this register?
+66 39 D0                    # cmp eax, edx              ; on success, eax must have been reset to "SMAP"
+75 5A                       # jne short failed
+66 85 DB                    # test ebx, ebx             ; ebx = 0 implies list is only 1 entry long (worthless)
+74 55                       # je short failed
+EB 1F                       # jmp short jmpin
+#:e820lp
+66 B8 20 E8 00 00           # mov eax, 0xE820           ; eax, ecx get trashed on every int 0x15 call
+26 66 C7 45 14 01 00 00 00  # mov [es:di + 20], dword 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes again
+CD 15                       # int 0x15
+72 34                       # jc short e820f            ; carry set means "end of list already reached"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; repair potentially trashed register
+#:jmpin
+E3 27                       # jcxz skipent              ; skip any 0 length entries
+80 F9 14                    # cmp cl, 20                ; got a 24 byte ACPI 3.X response?
+76 07                       # jbe short notext
+26 F6 45 14 01              # test byte ptr es:[di + 20], 1 ; if so: is the "ignore this data" bit clear?
+74 1B                       # je short skipent
+#:notext
+26 66 8B 4D 08              # mov ecx, es:[di + 8]      ; get lower uint32_t of memory region length
+26 66 0B 4D 0C              # or ecx, es:[di + 12]      ; "or" it with upper uint32_t to test for zero
+74 0F                       # jz skipent                ; if length uint64_t is 0, skip entry
+83 C5 18                    # add bp, 24                ; got a good entry: ++count, move to next storage spot
+26 66 C7 45 FC 14 00 00 00  # mov dword ptr es:[di - 4], 20 ; set multiboot entry size
+83 C7 18                    # add di, 24
+#:skipent
+66 85 DB                    # test ebx, ebx             ; if ebx resets to 0, list is complete
+75 B3                       # jne short e820lp
+#:e820f
+26 66 89 2E 00 08           # mov es:[0x800], ebp       ; store the structure size
+#:failed
+07                          # pop es
+66 9D                       # popfd
+66 61                       # popad
+
+# start 32bit mode
+FA                      # cli
+0F 01 06 8E 7F              # sgdt Saved_GDT_locator
 0F 01 16 88 7F          # lgdt GDT_locator
 0F 20 C0                # mov eax, cr0
 66 83 C8 01             # or eax, 0x01
 0F 22 C0                # mov cr0, eax
-EA 14 80 08 00          # jmp setup_32bit     ; sets CS
+EA B2 80 08 00          # jmp setup_32bit     ; sets CS
 
 #------
-#[8014]
+#[80B2]
 #:setup_32bit
 66 B8 10 00             # mov ax, 0x0010      ; data descriptor
 8E D8                   # mov ds, ax
@@ -550,32 +602,32 @@ BD 00 00 00 08          # mov ebp, 0x08000000
 89 EC                   # mov esp, ebp
 
 E8 05 00 00 00          # call setup_int_handlers
-E9 7D 0B 00 00          # jmp internalshell
+E9 75 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
-#[8033]
+#[80D1]
 #:setup_int_handlers
 53                        # push ebx
 
 # handle the timer interrupt 08
 BB 40 00 01 00            # mov ebx, &interrupt_table[08]
-66 C7 03 7D 80                       # mov word [ebx + 0], low_address stub_interrupt_handler
+66 C7 03 1B 81                       # mov word [ebx + 0], low_address stub_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # handle int 80
 BB 00 04 01 00            # mov ebx, &interrupt_table[80]
-66 C7 03 CB 81                       # mov word [ebx + 0], low_address syscall_interrupt_handler
+66 C7 03 5B 82                       # mov word [ebx + 0], low_address syscall_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # load the interrupt table
 FA                        # cli
-0F 01 1D 90 80 00 00      # lidt IDT_locator_32
-8B 1D 80 80 00 00         # mov ebx, [have_userspace]
+0F 01 1D 20 81 00 00      # lidt IDT_locator_32
+8B 1D 1C 81 00 00         # mov ebx, [have_userspace]
 85 DB                     # test ebx
 74 01                     # jz before_userspace
 FB                        # sti
@@ -585,28 +637,25 @@ C3                        # ret
 
 
 #----------------------------------------
-#[807D]
+#[811B]
 #:stub_interrupt_handler
 CF                    # iret
 
 #----------------------------------------
-#[807E]
-#:Init_A20
-00 00
-
-#----------------------------------------
-#[8080]
+#[811C]
 #:have_userspace
 00 00 00 00
 
-# align IDT locator to 16 byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00
-
 #----------------------------------------
-#[8090]
+#[8120]
 #:IDT_locator_32
 FF 07        #  length
 00 00 01 00  #  IDT_start
+
+#----------------------------------------
+#[8126]
+#:Init_A20
+00 00
 
 
 #------------------------------------------------------------
@@ -624,7 +673,7 @@ FF 07        #  length
 # 7B00  <- top of real mode stack
 
 #----------------------------------------
-#[8096]
+#[8128]
 #:enter_16bit_real
 FA                        # cli
 A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these locally
@@ -635,9 +684,9 @@ A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these lo
 # The following far jump sets CS to a 16-bit protected mode selector
 # and the segment registers are also set to 16-bit protected mode selectors.
 # This is done prior to entering real mode.
-EA B0 80 00 00  18 00 # jmp 0x18:setup_16bit
+EA 42 81 00 00  18 00 # jmp 0x18:setup_16bit
 #------
-#[80B0]
+#[8142]
 #:setup_16bit
 B8 20 00                  # mov ax, 0x0020
 8E D0                     # mov ss, ax
@@ -651,9 +700,9 @@ BC 00 7B                  # mov sp, 0x7B00
 0F 22 C0                  # mov cr0, eax
 # The following far jump sets CS to a 16-bit real mode segment
 # and the segment registers are also set to real mode segments.
-EA CF 80 00 00            # jmp 0000:XXXX  real_mode
+EA 61 81 00 00            # jmp 0000:XXXX  real_mode
 #------
-#[80CF]
+#[8161]
 #:real_mode
 B8 00 00                  # mov ax, 0x0
 8E D8                     # mov ds, ax
@@ -663,12 +712,12 @@ B8 00 00                  # mov ax, 0x0
 8E C0                     # mov es, ax
 BC 00 7B                  # mov sp, 0x7B00
 FA                        # cli
-0F 01 1E 10 81            # lidt IDT_locator_16
+0F 01 1E A0 81            # lidt IDT_locator_16
 0F 01 16 8E 7F              # lgdt Saved_GDT_locator
 FB                        # sti
 
 # Reset Gate A20 if needed
-A1 7E 80                  # mov ax, word ptr [Init_A20]
+A1 26 81                  # mov ax, word ptr [Init_A20]
 85 C0                     # test ax, ax
 75 05                     # jnz enter_no_a20
 B8 00 24                  # mov ax,2400h     # disable A20 line
@@ -686,20 +735,20 @@ A1 08 7B                  # mov ax, [0x7B08]  ; restore from above
 CB                        # retf
 
 # align IDT locator to 16-byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
 
 #------
-#[8110]
+#[81A0]
 #:IDT_locator_16
 FF 03
 00 00 00 00
 
 
 #----------------------------------------
-#[8116]
+#[81A6]
 #:resume_32bit_mode
 50                           # push ax
-A1 7E 80                     # mov ax, word ptr [Init_A20]
+A1 26 81                     # mov ax, word ptr [Init_A20]
 85 C0                        # test ax, ax
 75 05                        # jnz exit_no_a20
 
@@ -719,9 +768,9 @@ A3 08 7B                     # mov [0x7B08], ax  ; preserve, they might be retur
 0F 20 C0                     # mov eax, cr0
 66 83 C8 01                  # or eax, 0x01         ; enable protected mode
 0F 22 C0                     # mov cr0, eax
-EA 47 81 08 00               # jmp restore_32bit
+EA D7 81 08 00               # jmp restore_32bit
 #------
-#[8147]
+#[81D7]
 #:restore_32bit
 B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E D8                        # mov ds, eax
@@ -730,7 +779,7 @@ B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E E0                        # mov fs, eax
 8E E8                        # mov gs, eax
 8B 25 04 7B 00 00            # mov esp, [0x7B04]   ; restore, (saved in enter_16bit_mode)
-E8 D2 FE FF FF               # call setup_int_handlers
+E8 E0 FE FF FF               # call setup_int_handlers
 52                           # push edx            ; setup our return location
 # These restore the 16 bit portion of these registers, which may be a
 # return value from a 16 bit function, and they also restore any previous high
@@ -742,26 +791,26 @@ C3                           # ret
 
 
 #------------------------
-#[816E]
+#[81FE]
 #:console_putc
 #
-E8 23 FF FF FF          # call enter_16bit_real
-E8 9E FC                # call console_putc_16(al)
-9A 16 81 00 00          # call resume_32bit_mode
+E8 25 FF FF FF          # call enter_16bit_real
+E8 0E FC                # call console_putc_16(al)
+9A A6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[817C]
+#[820C]
 #:console_put_hex
-E8 15 FF FF FF          # call enter_16bit_real
-E8 A6 FC                # call console_put_hex_16(al)
-9A 16 81 00 00          # call resume_32bit_mode
+E8 17 FF FF FF          # call enter_16bit_real
+E8 16 FC                # call console_put_hex_16(al)
+9A A6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[818A]
+#[821A]
 #:console_puts
 # inputs
 #   ds:si: string to print
@@ -783,42 +832,42 @@ C3                      # ret
 
 
 #------------------------
-#[81A4]
+#[8234]
 #:read_sectors
 # inputs:
 #   di: dest_addr
 #   ecx: first logical sector
 #   ax: num_sectors
 #
-E8 ED FE FF FF          # call enter_16bit_real
-E8 C4 FC                # call read_sectors_16
-9A 16 81 00 00          # call resume_32bit_mode
+E8 EF FE FF FF          # call enter_16bit_real
+E8 34 FC                # call read_sectors_16
+9A A6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[81B2]
+#[8242]
 #:write_sectors
 # inputs:
 #   si: source_addr
 #   ecx: first logical sector
 #   ax: num_sectors
 #
-E8 DF FE FF FF          # call enter_16bit_real
-E8 2D FD                # call write_sectors_16
-9A 16 81 00 00          # call resume_32bit_mode
+E8 E1 FE FF FF          # call enter_16bit_real
+E8 9D FC                # call write_sectors_16
+9A A6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 #------------------------
-#[81C0]
+#[8250]
 #:reboot
-E8 D1 FE FF FF          # call enter_16bit_real
+E8 D3 FE FF FF          # call enter_16bit_real
 FA                      # cli
 EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 
 
 #------------------------
-#[81CB]
+#[825B]
 #:syscall_interrupt_handler
 #
 3C 01                             # cmp al, 1
@@ -918,17 +967,17 @@ CF                                # iret
 
 
 #------
-#[8263]
+#[82F3]
 #:next_filenum
 04 00 00 00
 
 #------
-#[8267]
+#[82F7]
 #:next_file_address
 00 00 00 54
 
 #----------------------------------------
-#[826B]
+#[82FB]
 #:handle_syscall_open
 # inputs:
 #   ebx: filename
@@ -983,7 +1032,7 @@ E9 80 00 00 00              # jmp open_finish_fail
 # copy filename to new slot
 89 DE                       # mov esi, ebx
 BF 00 00 20 00              # mov edi, 0x0200000
-A1 63 82 00 00              # mov eax, [next_filenum]
+A1 F3 82 00 00              # mov eax, [next_filenum]
 C1 E0 0A                    # shl eax, 0a
 01 C7                       # add edi, eax
 B9 00 04 00 00              # mov ecx, 0x0000400
@@ -991,18 +1040,18 @@ F3 A4                       # rep movsb
 
 # set address of file
 BF 00 00 00 01              # mov edi, 0x01000000           ; pfile_descriptor = &file_descriptor[0]
-A1 63 82 00 00              # mov eax, [next_filenum]
+A1 F3 82 00 00              # mov eax, [next_filenum]
 C1 E0 04                    # shl eax, 04
 01 C7                       # add edi, eax                  ; pfile_descriptor += sizeof(file_descriptor) * next_filenum
-8B 0D 67 82 00 00           # mov ecx, [next_file_address]
+8B 0D F7 82 00 00           # mov ecx, [next_file_address]
 
 89 4F 04                    # mov [edi+4], ecx              ; pfile_descriptor->file_addr = ecx
 
 31 C0                       # xor eax, eax
 89 47 08                    # mov [edi+8], eax              ; pfile_descriptor->length = 0
 
-A1 63 82 00 00              # mov eax, [next_filenum]       ; return next_filenum
-FF 05 63 82 00 00           # inc [next_filenum]
+A1 F3 82 00 00              # mov eax, [next_filenum]       ; return next_filenum
+FF 05 F3 82 00 00           # inc [next_filenum]
 EB 16                       # jmp syscall_open_finish
 
 #:open_read
@@ -1017,7 +1066,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 DE 85 00 00           # mov esi, [next_process_num]
+8B 35 6E 86 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1039,7 +1088,7 @@ EB F4                       # jmp find_slot_loop
 89 4E 04                    # mov [esi+0x4], ecx
 
 #--------
-#[8328]
+#[83B8]
 #:open_finish_fail
 
 5F                          # pop edi
@@ -1050,13 +1099,13 @@ C3                          # ret
 
 
 #----------------------------------------
-#[832D]
+#[83BD]
 #:handle_syscall_close
 # inputs:
 #   ebx: fd
 
 57                          # push edi
-8B 3D DE 85 00 00           # mov edi, [next_process_num]
+8B 3D 6E 86 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1067,7 +1116,7 @@ C3                          # ret
 
 
 #----------------------------------------
-#[8345]
+#[83D5]
 #:absolute_path
 # inputs:
 #   ebx: path
@@ -1087,7 +1136,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 DE 85 00 00             # mov esi, [next_process_num]
+8B 35 6E 86 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1204,7 +1253,7 @@ C3                            # ret
 
 
 #----------------------------------------
-#[83E2]
+#[8472]
 #:find_file
 # inputs:
 #   ebx: file_name
@@ -1216,12 +1265,12 @@ C3                            # ret
 56                    # push esi
 57                    # push edi
 
-A1 63 82 00 00        # mov eax, [next_filenum]
+A1 F3 82 00 00        # mov eax, [next_filenum]
 48                    # dec eax
 89 DE                 # mov esi, ebx
 
 #:checkfile
-83 F8 03              # cmp eax, 3
+83 F8 02              # cmp eax, 2
 74 15                 # je not_found
 89 C7                 # mov edi, eax
 C1 E7 0A              # shl edi, 0x0a
@@ -1243,14 +1292,14 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8412]
+#[84A2]
 #:fd_to_file_index
 # inputs:
 #   ebx: file descriptor number
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D DE 85 00 00        # mov edi, [next_process_num]
+8B 3D 6E 86 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1260,7 +1309,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8428]
+#[84B8]
 #:handle_syscall_read
 # inputs:
 #   ecx: *return_char
@@ -1337,7 +1386,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 DE 85 00 00        # mov esi, [next_process_num]
+8B 35 6E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1369,11 +1418,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[84D6]
+#[8566]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1408,7 +1457,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8505]
+#[8595]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1442,7 +1491,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D DE 85 00 00         # mov ecx, [next_process_num]
+8B 0D 6E 86 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1469,7 +1518,7 @@ FF 01                     # inc long [ecx]       ; current_offset++
 3B 43 08                  # cmp eax, [ebx+0x8]
 7E 09                     # jle skip_lengthen
 FF 43 08                  # inc long [ebx+0x8]   ; file_length++
-FF 05 67 82 00 00         # inc long [next_file_address]
+FF 05 F7 82 00 00         # inc long [next_file_address]
 #:skip_lengthen
 58                        # pop eax
 40                        # inc eax              ; num_written++
@@ -1485,12 +1534,12 @@ C3                        # ret
 
 
 #------
-#[8570]
+#[8600]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8574]
+#[8604]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1499,7 +1548,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1512,12 +1561,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 70 85 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 00 86 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 70 85 00 00                 # add [next_save_process_address], ecx
+01 0D 00 86 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1532,7 +1581,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 70 85 00 00                 # add [next_save_process_address], ecx
+01 0D 00 86 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1546,12 +1595,12 @@ C3                    # ret
 
 
 #------
-#[85DE]
+#[866E]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[85E2]
+#[8672]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1559,7 +1608,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1579,19 +1628,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 70 85 00 00                 # mov edi, [next_save_process_address]
+8B 3D 00 86 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1641,13 +1690,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 70 85 00 00                 # mov [next_save_process_address], edi
+89 3D 00 86 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1734,7 +1783,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 DE 85 00 00           # inc [next_process_num]
+FF 05 6E 86 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1750,7 +1799,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[871D]
+#[87AD]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
@@ -1771,7 +1820,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D DE 85 00 00           # mov edi, [next_process_num]
+8B 3D 6E 86 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1805,11 +1854,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8770]
+#[8800]
 #:handle_syscall_exit
-A1 DE 85 00 00        # mov eax, [next_process_num]
+A1 6E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 DE 85 00 00        # mov [next_process_num], eax
+A3 6E 86 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1829,7 +1878,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 70 85 00 00                 # mov [next_save_process_address], esi
+89 35 00 86 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1852,9 +1901,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[87C4]
+#[8854]
 #:handle_syscall_waitpid
-8B 35 DE 85 00 00        # mov esi, [next_process_num]
+8B 35 6E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1866,7 +1915,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[87DE]
+#[886E]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1877,7 +1926,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 DE 85 00 00           # mov esi, [next_process_num]
+8B 35 6E 86 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1918,7 +1967,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8824]
+#[88B4]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
@@ -1933,7 +1982,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[8836]
+#[88C6]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
@@ -1950,7 +1999,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[884A]
+#[88DA]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -1961,7 +2010,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 DE 85 00 00        # mov esi, [next_process_num]
+8B 35 6E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1988,7 +2037,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8877]
+#[8907]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2022,19 +2071,19 @@ C3                    # ret
 
 
 #------
-#[8892]
+#[8922]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8894]
+#[8924]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 92 88 00 00        # mov ecx, io_char
+B9 22 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2043,7 +2092,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 92 88 00 00        # mov al, io_char
+A0 22 89 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2053,16 +2102,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[88B7]
+#[8947]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 92 88 00 00        # mov io_char, al
+A2 22 89 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 92 88 00 00        # mov ecx, io_char
+B9 22 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2074,7 +2123,7 @@ C3                    # ret
 
 
 #------
-#[88D6]
+#[8966]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2088,7 +2137,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[88DA]
+#[896A]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2097,7 +2146,7 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE D6 88 00 00          # mov esi, string_src
+BE 66 89 00 00          # mov esi, string_src
 E8 A0 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
@@ -2181,19 +2230,19 @@ C3                      # ret
 
 
 #------
-#[8979]
+#[8A09]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[897E]
+#[8A0E]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 79 89 00 00          # mov esi, hex0_str
+BE 09 8A 00 00          # mov esi, hex0_str
 E8 FF F7 FF FF          # call console_puts
 
 # read "ex0 '
@@ -2258,7 +2307,7 @@ CD 80                   # int 80
 
 
 #------
-#[8A05]
+#[8A95]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2348,18 +2397,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8A72]
+#[8B02]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[8A7A]
+#[8B0A]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[8A7E]
+#[8B0E]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2367,7 +2416,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D 01 8B 00 00   00     # cmp [enable_flush], 0
+83 3D 91 8B 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2386,7 +2435,7 @@ B9 FF 07 00 00             # mov ecx, 0x000007FF
 
 # no more reading from disk - enable interrupts
 40                         # inc eax
-A3 80 80 00 00             # mov [have_userspace], eax
+A3 1C 81 00 00             # mov [have_userspace], eax
 FB                         # sti
 
 BA 01 00 D0 04             # mov edx, 0x04D00001
@@ -2416,8 +2465,8 @@ BE 00 04 D0 04             # mov esi, arg1
 E8 A3 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 72 8A 00 00             # mov ecx, cmd_args
-BA 7A 8A 00 00             # mov edx, cmd_env
+B9 02 8B 00 00             # mov ecx, cmd_args
+BA 0A 8B 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2428,22 +2477,22 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[8B01]
+#[8B91]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[8B05]
+#[8B95]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB A7 8B 00 00           # mov ebx, str_dev_hda
+BB 37 8C 00 00           # mov ebx, str_dev_hda
 E8 D2 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 91 8B 00 00           # mov esi, str_error_no_write
+BE 21 8C 00 00           # mov esi, str_error_no_write
 E8 6B F6 FF FF           # call console_puts
 
 # one space to flush last line
@@ -2499,28 +2548,53 @@ C3                       # ret
 
 
 #------
-#[8B81]
+#[8C11]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8B91]
+#[8C21]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[8BA7]
+#[8C37]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
+#------
+#[8C40]
+#:str_e820
+#/  e  8  2  0 \0
+2F 65 38 32 30 00
+
 
 #------------------------------------------------------------
-#[8BB0]
+#[8C46]
 #:internalshell
-B8 00 7E 00 00                 # mov eax, $kernel_entry
+
+# clear file name table
+BF 00 00 20 00                 # mov edi, 0x00200000
+B9 00 00 E0 00                 # mov ecx, 0x00E00000
+31 C0                          # xor eax, eax
+F3 AA                          # rep stosb
+
+# check for an E820 memory map
+A1 00 08 01 00                 # mov eax, [0x10800]
+85 C0                          # test eax, eax
+74 20                          # jz no_e820
+A3 38 00 00 01                 # mov [0x1000038], eax
+C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
+BE 40 8C 00 00                 # mov esi, str_e820
+BF 00 0C 20 00                 # mov edi, 0x200C00
+B9 06 00 00 00                 # mov ecx, 6
+F3 A4                          # rep movsb
+
+#:no_e820
+B8 00 7E 00 00                 # mov eax, &kernel_entry
 3D 00 7C 00 00                 # cmp eax, 0x00007C00
 75 0C                          # jne stage2_stdin
 
@@ -2529,8 +2603,8 @@ C7 05 00 00 00 01 08 00 00 00  # mov word [0x01000000], 0x00000008
 EB 0A                          # jmp after_set_stdin
 
 #:stage2_stdin
-# Start reading stdin from logical sector 168
-C7 05 00 00 00 01 A8 00 00 00  # mov word [0x01000000], 0x000000A8
+# Start reading stdin from logical sector 175
+C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 #:after_set_stdin
 # start at "end of sector" to trigger an initial sector read
@@ -2544,16 +2618,11 @@ B9 00 0E 00 00                 # mov ecx, 0x00000E00
 31 C0                          # xor eax, eax
 F3 AA                          # rep stosb
 
-# clear file name table
-BF 00 00 20 00                 # mov edi, 0x00200000
-B9 00 00 E0 00                 # mov ecx, 0x00E00000
-F3 AA                          # rep stosb
-
 # read from stdin
 31 DB                          # xor ebx, ebx
 
 #:process_command
-E8 86 FC FF FF                 # call read
+E8 55 FC FF FF                 # call read
 3C 00                          # cmp al, 0
 74 2E                          # je build_finished
 
@@ -2562,7 +2631,7 @@ E8 86 FC FF FF                 # call read
 75 07                          # jne check_hex0_command
 
 #:handle_src_command
-E8 BF FC FF FF                 # call src
+E8 8E FC FF FF                 # call src
 EB EC                          # jmp process_command
 
 #:check_hex0_command
@@ -2570,7 +2639,7 @@ EB EC                          # jmp process_command
 75 07                          # jne check_flush_command
 
 #:handle_hex0_command
-E8 58 FD FF FF                 # call hex0
+E8 27 FD FF FF                 # call hex0
 EB E1                          # jmp process_command
 
 #:check_flush_command
@@ -2578,40 +2647,25 @@ EB E1                          # jmp process_command
 75 0D                          # jne call_handle_other_command
 
 #:handle_flush_command
-E8 63 FC FF FF                 # call read    ; read the newline
-FF 05 01 8B 00 00              # inc dword [enable_flush]
+E8 32 FC FF FF                 # call read    ; read the newline
+FF 05 91 8B 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
-E8 40 FE FF FF                 # call handle_other_command
+E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 81 8B 00 00                 # mov esi, str_build_finished
-E8 40 F5 FF FF                 # call console_puts
+BE 11 8C 00 00                 # mov esi, str_build_finished
+E8 0F F5 FF FF                 # call console_puts
 
-E8 B6 FE FF FF                 # call flush_disk
+E8 85 FE FF FF                 # call flush_disk
 
 #:shell_reboot
-E9 6C F5 FF FF                 # jmp reboot
+E9 3B F5 FF FF                 # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 

--- a/builder-hex0.hex0
+++ b/builder-hex0.hex0
@@ -96,7 +96,7 @@
 #                      0x100  0x100  current directory
 #                      0x200  x0E00  file descriptors 448 * 8 bytes each
 #                                    { global_file_index, current_offset }
-#    10800 -    1FFFF unused
+#    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
 #     A000 -     A1FF sector read buffer - 16bit
 #     7C00 -     8600 code
@@ -511,7 +511,7 @@ FB                      # sti
 1F                      # pop ds
 9D                      # popf
 
-A3 7E 7E                # mov word ptr [Init_A20], ax
+A3 26 7F                # mov word ptr [Init_A20], ax
 85 C0                   # test ax, ax
 75 05                   # jnz init_no_a20
 
@@ -520,25 +520,77 @@ B8 01 24                # mov ax,2401h     # enable A20 line
 CD 15                   # int 15h
 
 #:init_no_a20
-# start 32bit mode
-FA                      # cli
-0F 01 06 8E 7D              # sgdt Saved_GDT_locator
-EB 06                   # jmp past_MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
+
+# adapted from https://wiki.osdev.org/Detecting_Memory_(x86)#Getting_an_E820_Memory_Map
+# use the INT 0x15, eax=0xE820 BIOS function to get a memory map
+
+66 60                       # pushad
+66 9C                       # pushfd
+06                          # push es
+68 00 10                    # push 0x1000
+07                          # pop es
+EB 03                       # jmp past_MBR
+90                          # nop    ; padding to align MBR
 # This is the DOS/MBR identifier at offset 510:
 55 AA
 #:past_MBR
+66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
+26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
+BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
+66 31 ED                    # xor ebp, ebp              ; keep an entry count in bp
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; place "SMAP" into edx
+66 B8 20 E8 00 00           # mov eax, 0xE820
+26 66 C7 45 14 01 00 00 00  # mov dword ptr es:[di + 20], 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes
+CD 15                       # int 0x15
+72 65                       # jc short failed           ; carry set on first call means "unsupported function"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; Some BIOSes apparently trash this register?
+66 39 D0                    # cmp eax, edx              ; on success, eax must have been reset to "SMAP"
+75 5A                       # jne short failed
+66 85 DB                    # test ebx, ebx             ; ebx = 0 implies list is only 1 entry long (worthless)
+74 55                       # je short failed
+EB 1F                       # jmp short jmpin
+#:e820lp
+66 B8 20 E8 00 00           # mov eax, 0xE820           ; eax, ecx get trashed on every int 0x15 call
+26 66 C7 45 14 01 00 00 00  # mov [es:di + 20], dword 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes again
+CD 15                       # int 0x15
+72 34                       # jc short e820f            ; carry set means "end of list already reached"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; repair potentially trashed register
+#:jmpin
+E3 27                       # jcxz skipent              ; skip any 0 length entries
+80 F9 14                    # cmp cl, 20                ; got a 24 byte ACPI 3.X response?
+76 07                       # jbe short notext
+26 F6 45 14 01              # test byte ptr es:[di + 20], 1 ; if so: is the "ignore this data" bit clear?
+74 1B                       # je short skipent
+#:notext
+26 66 8B 4D 08              # mov ecx, es:[di + 8]      ; get lower uint32_t of memory region length
+26 66 0B 4D 0C              # or ecx, es:[di + 12]      ; "or" it with upper uint32_t to test for zero
+74 0F                       # jz skipent                ; if length uint64_t is 0, skip entry
+83 C5 18                    # add bp, 24                ; got a good entry: ++count, move to next storage spot
+26 66 C7 45 FC 14 00 00 00  # mov dword ptr es:[di - 4], 20 ; set multiboot entry size
+83 C7 18                    # add di, 24
+#:skipent
+66 85 DB                    # test ebx, ebx             ; if ebx resets to 0, list is complete
+75 B3                       # jne short e820lp
+#:e820f
+26 66 89 2E 00 08           # mov es:[0x800], ebp       ; store the structure size
+#:failed
+07                          # pop es
+66 9D                       # popfd
+66 61                       # popad
+
+# start 32bit mode
+FA                      # cli
+0F 01 06 8E 7D              # sgdt Saved_GDT_locator
 0F 01 16 88 7D          # lgdt GDT_locator
 0F 20 C0                # mov eax, cr0
 66 83 C8 01             # or eax, 0x01
 0F 22 C0                # mov cr0, eax
-EA 14 7E 08 00          # jmp setup_32bit     ; sets CS
+EA B2 7E 08 00          # jmp setup_32bit     ; sets CS
 
 #------
-#[7E14]
+#[7EB2]
 #:setup_32bit
 66 B8 10 00             # mov ax, 0x0010      ; data descriptor
 8E D8                   # mov ds, ax
@@ -550,32 +602,32 @@ BD 00 00 00 08          # mov ebp, 0x08000000
 89 EC                   # mov esp, ebp
 
 E8 05 00 00 00          # call setup_int_handlers
-E9 7D 0B 00 00          # jmp internalshell
+E9 75 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
-#[7E33]
+#[7ED1]
 #:setup_int_handlers
 53                        # push ebx
 
 # handle the timer interrupt 08
 BB 40 00 01 00            # mov ebx, &interrupt_table[08]
-66 C7 03 7D 7E                       # mov word [ebx + 0], low_address stub_interrupt_handler
+66 C7 03 1B 7F                       # mov word [ebx + 0], low_address stub_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # handle int 80
 BB 00 04 01 00            # mov ebx, &interrupt_table[80]
-66 C7 03 CB 7F                       # mov word [ebx + 0], low_address syscall_interrupt_handler
+66 C7 03 5B 80                       # mov word [ebx + 0], low_address syscall_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # load the interrupt table
 FA                        # cli
-0F 01 1D 90 7E 00 00      # lidt IDT_locator_32
-8B 1D 80 7E 00 00         # mov ebx, [have_userspace]
+0F 01 1D 20 7F 00 00      # lidt IDT_locator_32
+8B 1D 1C 7F 00 00         # mov ebx, [have_userspace]
 85 DB                     # test ebx
 74 01                     # jz before_userspace
 FB                        # sti
@@ -585,28 +637,25 @@ C3                        # ret
 
 
 #----------------------------------------
-#[7E7D]
+#[7F1B]
 #:stub_interrupt_handler
 CF                    # iret
 
 #----------------------------------------
-#[7E7E]
-#:Init_A20
-00 00
-
-#----------------------------------------
-#[7E80]
+#[7F1C]
 #:have_userspace
 00 00 00 00
 
-# align IDT locator to 16 byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00
-
 #----------------------------------------
-#[7E90]
+#[7F20]
 #:IDT_locator_32
 FF 07        #  length
 00 00 01 00  #  IDT_start
+
+#----------------------------------------
+#[7F26]
+#:Init_A20
+00 00
 
 
 #------------------------------------------------------------
@@ -624,7 +673,7 @@ FF 07        #  length
 # 7B00  <- top of real mode stack
 
 #----------------------------------------
-#[7E96]
+#[7F28]
 #:enter_16bit_real
 FA                        # cli
 A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these locally
@@ -635,9 +684,9 @@ A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these lo
 # The following far jump sets CS to a 16-bit protected mode selector
 # and the segment registers are also set to 16-bit protected mode selectors.
 # This is done prior to entering real mode.
-EA B0 7E 00 00  18 00 # jmp 0x18:setup_16bit
+EA 42 7F 00 00  18 00 # jmp 0x18:setup_16bit
 #------
-#[7EB0]
+#[7F42]
 #:setup_16bit
 B8 20 00                  # mov ax, 0x0020
 8E D0                     # mov ss, ax
@@ -651,9 +700,9 @@ BC 00 7B                  # mov sp, 0x7B00
 0F 22 C0                  # mov cr0, eax
 # The following far jump sets CS to a 16-bit real mode segment
 # and the segment registers are also set to real mode segments.
-EA CF 7E 00 00            # jmp 0000:XXXX  real_mode
+EA 61 7F 00 00            # jmp 0000:XXXX  real_mode
 #------
-#[7ECF]
+#[7F61]
 #:real_mode
 B8 00 00                  # mov ax, 0x0
 8E D8                     # mov ds, ax
@@ -663,12 +712,12 @@ B8 00 00                  # mov ax, 0x0
 8E C0                     # mov es, ax
 BC 00 7B                  # mov sp, 0x7B00
 FA                        # cli
-0F 01 1E 10 7F            # lidt IDT_locator_16
+0F 01 1E A0 7F            # lidt IDT_locator_16
 0F 01 16 8E 7D              # lgdt Saved_GDT_locator
 FB                        # sti
 
 # Reset Gate A20 if needed
-A1 7E 7E                  # mov ax, word ptr [Init_A20]
+A1 26 7F                  # mov ax, word ptr [Init_A20]
 85 C0                     # test ax, ax
 75 05                     # jnz enter_no_a20
 B8 00 24                  # mov ax,2400h     # disable A20 line
@@ -686,20 +735,20 @@ A1 08 7B                  # mov ax, [0x7B08]  ; restore from above
 CB                        # retf
 
 # align IDT locator to 16-byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
 
 #------
-#[7F10]
+#[7FA0]
 #:IDT_locator_16
 FF 03
 00 00 00 00
 
 
 #----------------------------------------
-#[7F16]
+#[7FA6]
 #:resume_32bit_mode
 50                           # push ax
-A1 7E 7E                     # mov ax, word ptr [Init_A20]
+A1 26 7F                     # mov ax, word ptr [Init_A20]
 85 C0                        # test ax, ax
 75 05                        # jnz exit_no_a20
 
@@ -719,9 +768,9 @@ A3 08 7B                     # mov [0x7B08], ax  ; preserve, they might be retur
 0F 20 C0                     # mov eax, cr0
 66 83 C8 01                  # or eax, 0x01         ; enable protected mode
 0F 22 C0                     # mov cr0, eax
-EA 47 7F 08 00               # jmp restore_32bit
+EA D7 7F 08 00               # jmp restore_32bit
 #------
-#[7F47]
+#[7FD7]
 #:restore_32bit
 B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E D8                        # mov ds, eax
@@ -730,7 +779,7 @@ B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E E0                        # mov fs, eax
 8E E8                        # mov gs, eax
 8B 25 04 7B 00 00            # mov esp, [0x7B04]   ; restore, (saved in enter_16bit_mode)
-E8 D2 FE FF FF               # call setup_int_handlers
+E8 E0 FE FF FF               # call setup_int_handlers
 52                           # push edx            ; setup our return location
 # These restore the 16 bit portion of these registers, which may be a
 # return value from a 16 bit function, and they also restore any previous high
@@ -742,26 +791,26 @@ C3                           # ret
 
 
 #------------------------
-#[7F6E]
+#[7FFE]
 #:console_putc
 #
-E8 23 FF FF FF          # call enter_16bit_real
-E8 9E FC                # call console_putc_16(al)
-9A 16 7F 00 00          # call resume_32bit_mode
+E8 25 FF FF FF          # call enter_16bit_real
+E8 0E FC                # call console_putc_16(al)
+9A A6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[7F7C]
+#[800C]
 #:console_put_hex
-E8 15 FF FF FF          # call enter_16bit_real
-E8 A6 FC                # call console_put_hex_16(al)
-9A 16 7F 00 00          # call resume_32bit_mode
+E8 17 FF FF FF          # call enter_16bit_real
+E8 16 FC                # call console_put_hex_16(al)
+9A A6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[7F8A]
+#[801A]
 #:console_puts
 # inputs
 #   ds:si: string to print
@@ -783,42 +832,42 @@ C3                      # ret
 
 
 #------------------------
-#[7FA4]
+#[8034]
 #:read_sectors
 # inputs:
 #   di: dest_addr
 #   ecx: first logical sector
 #   ax: num_sectors
 #
-E8 ED FE FF FF          # call enter_16bit_real
-E8 C4 FC                # call read_sectors_16
-9A 16 7F 00 00          # call resume_32bit_mode
+E8 EF FE FF FF          # call enter_16bit_real
+E8 34 FC                # call read_sectors_16
+9A A6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[7FB2]
+#[8042]
 #:write_sectors
 # inputs:
 #   si: source_addr
 #   ecx: first logical sector
 #   ax: num_sectors
 #
-E8 DF FE FF FF          # call enter_16bit_real
-E8 2D FD                # call write_sectors_16
-9A 16 7F 00 00          # call resume_32bit_mode
+E8 E1 FE FF FF          # call enter_16bit_real
+E8 9D FC                # call write_sectors_16
+9A A6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 #------------------------
-#[7FC0]
+#[8050]
 #:reboot
-E8 D1 FE FF FF          # call enter_16bit_real
+E8 D3 FE FF FF          # call enter_16bit_real
 FA                      # cli
 EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 
 
 #------------------------
-#[7FCB]
+#[805B]
 #:syscall_interrupt_handler
 #
 3C 01                             # cmp al, 1
@@ -918,17 +967,17 @@ CF                                # iret
 
 
 #------
-#[8063]
+#[80F3]
 #:next_filenum
 04 00 00 00
 
 #------
-#[8067]
+#[80F7]
 #:next_file_address
 00 00 00 54
 
 #----------------------------------------
-#[806B]
+#[80FB]
 #:handle_syscall_open
 # inputs:
 #   ebx: filename
@@ -983,7 +1032,7 @@ E9 80 00 00 00              # jmp open_finish_fail
 # copy filename to new slot
 89 DE                       # mov esi, ebx
 BF 00 00 20 00              # mov edi, 0x0200000
-A1 63 80 00 00              # mov eax, [next_filenum]
+A1 F3 80 00 00              # mov eax, [next_filenum]
 C1 E0 0A                    # shl eax, 0a
 01 C7                       # add edi, eax
 B9 00 04 00 00              # mov ecx, 0x0000400
@@ -991,18 +1040,18 @@ F3 A4                       # rep movsb
 
 # set address of file
 BF 00 00 00 01              # mov edi, 0x01000000           ; pfile_descriptor = &file_descriptor[0]
-A1 63 80 00 00              # mov eax, [next_filenum]
+A1 F3 80 00 00              # mov eax, [next_filenum]
 C1 E0 04                    # shl eax, 04
 01 C7                       # add edi, eax                  ; pfile_descriptor += sizeof(file_descriptor) * next_filenum
-8B 0D 67 80 00 00           # mov ecx, [next_file_address]
+8B 0D F7 80 00 00           # mov ecx, [next_file_address]
 
 89 4F 04                    # mov [edi+4], ecx              ; pfile_descriptor->file_addr = ecx
 
 31 C0                       # xor eax, eax
 89 47 08                    # mov [edi+8], eax              ; pfile_descriptor->length = 0
 
-A1 63 80 00 00              # mov eax, [next_filenum]       ; return next_filenum
-FF 05 63 80 00 00           # inc [next_filenum]
+A1 F3 80 00 00              # mov eax, [next_filenum]       ; return next_filenum
+FF 05 F3 80 00 00           # inc [next_filenum]
 EB 16                       # jmp syscall_open_finish
 
 #:open_read
@@ -1017,7 +1066,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 DE 83 00 00           # mov esi, [next_process_num]
+8B 35 6E 84 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1039,7 +1088,7 @@ EB F4                       # jmp find_slot_loop
 89 4E 04                    # mov [esi+0x4], ecx
 
 #--------
-#[8128]
+#[81B8]
 #:open_finish_fail
 
 5F                          # pop edi
@@ -1050,13 +1099,13 @@ C3                          # ret
 
 
 #----------------------------------------
-#[812D]
+#[81BD]
 #:handle_syscall_close
 # inputs:
 #   ebx: fd
 
 57                          # push edi
-8B 3D DE 83 00 00           # mov edi, [next_process_num]
+8B 3D 6E 84 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1067,7 +1116,7 @@ C3                          # ret
 
 
 #----------------------------------------
-#[8145]
+#[81D5]
 #:absolute_path
 # inputs:
 #   ebx: path
@@ -1087,7 +1136,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 DE 83 00 00             # mov esi, [next_process_num]
+8B 35 6E 84 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1204,7 +1253,7 @@ C3                            # ret
 
 
 #----------------------------------------
-#[81E2]
+#[8272]
 #:find_file
 # inputs:
 #   ebx: file_name
@@ -1216,12 +1265,12 @@ C3                            # ret
 56                    # push esi
 57                    # push edi
 
-A1 63 80 00 00        # mov eax, [next_filenum]
+A1 F3 80 00 00        # mov eax, [next_filenum]
 48                    # dec eax
 89 DE                 # mov esi, ebx
 
 #:checkfile
-83 F8 03              # cmp eax, 3
+83 F8 02              # cmp eax, 2
 74 15                 # je not_found
 89 C7                 # mov edi, eax
 C1 E7 0A              # shl edi, 0x0a
@@ -1243,14 +1292,14 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8212]
+#[82A2]
 #:fd_to_file_index
 # inputs:
 #   ebx: file descriptor number
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D DE 83 00 00        # mov edi, [next_process_num]
+8B 3D 6E 84 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1260,7 +1309,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8228]
+#[82B8]
 #:handle_syscall_read
 # inputs:
 #   ecx: *return_char
@@ -1337,7 +1386,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 DE 83 00 00        # mov esi, [next_process_num]
+8B 35 6E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1369,11 +1418,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[82D6]
+#[8366]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1408,7 +1457,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8305]
+#[8395]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1442,7 +1491,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D DE 83 00 00         # mov ecx, [next_process_num]
+8B 0D 6E 84 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1469,7 +1518,7 @@ FF 01                     # inc long [ecx]       ; current_offset++
 3B 43 08                  # cmp eax, [ebx+0x8]
 7E 09                     # jle skip_lengthen
 FF 43 08                  # inc long [ebx+0x8]   ; file_length++
-FF 05 67 80 00 00         # inc long [next_file_address]
+FF 05 F7 80 00 00         # inc long [next_file_address]
 #:skip_lengthen
 58                        # pop eax
 40                        # inc eax              ; num_written++
@@ -1485,12 +1534,12 @@ C3                        # ret
 
 
 #------
-#[8370]
+#[8400]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8374]
+#[8404]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1499,7 +1548,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1512,12 +1561,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 70 83 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 00 84 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 70 83 00 00                 # add [next_save_process_address], ecx
+01 0D 00 84 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1532,7 +1581,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 70 83 00 00                 # add [next_save_process_address], ecx
+01 0D 00 84 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1546,12 +1595,12 @@ C3                    # ret
 
 
 #------
-#[83DE]
+#[846E]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[83E2]
+#[8472]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1559,7 +1608,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1579,19 +1628,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 70 83 00 00                 # mov edi, [next_save_process_address]
+8B 3D 00 84 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1641,13 +1690,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 70 83 00 00                 # mov [next_save_process_address], edi
+89 3D 00 84 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1734,7 +1783,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 DE 83 00 00           # inc [next_process_num]
+FF 05 6E 84 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1750,7 +1799,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[851D]
+#[85AD]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
@@ -1771,7 +1820,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D DE 83 00 00           # mov edi, [next_process_num]
+8B 3D 6E 84 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1805,11 +1854,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8570]
+#[8600]
 #:handle_syscall_exit
-A1 DE 83 00 00        # mov eax, [next_process_num]
+A1 6E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 DE 83 00 00        # mov [next_process_num], eax
+A3 6E 84 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1829,7 +1878,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 70 83 00 00                 # mov [next_save_process_address], esi
+89 35 00 84 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1852,9 +1901,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[85C4]
+#[8654]
 #:handle_syscall_waitpid
-8B 35 DE 83 00 00        # mov esi, [next_process_num]
+8B 35 6E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1866,7 +1915,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[85DE]
+#[866E]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1877,7 +1926,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 DE 83 00 00           # mov esi, [next_process_num]
+8B 35 6E 84 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1918,7 +1967,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8624]
+#[86B4]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
@@ -1933,7 +1982,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[8636]
+#[86C6]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
@@ -1950,7 +1999,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[864A]
+#[86DA]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -1961,7 +2010,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 DE 83 00 00        # mov esi, [next_process_num]
+8B 35 6E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1988,7 +2037,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8677]
+#[8707]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2022,19 +2071,19 @@ C3                    # ret
 
 
 #------
-#[8692]
+#[8722]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8694]
+#[8724]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 92 86 00 00        # mov ecx, io_char
+B9 22 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2043,7 +2092,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 92 86 00 00        # mov al, io_char
+A0 22 87 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2053,16 +2102,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[86B7]
+#[8747]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 92 86 00 00        # mov io_char, al
+A2 22 87 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 92 86 00 00        # mov ecx, io_char
+B9 22 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2074,7 +2123,7 @@ C3                    # ret
 
 
 #------
-#[86D6]
+#[8766]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2088,7 +2137,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[86DA]
+#[876A]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2097,7 +2146,7 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE D6 86 00 00          # mov esi, string_src
+BE 66 87 00 00          # mov esi, string_src
 E8 A0 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
@@ -2181,19 +2230,19 @@ C3                      # ret
 
 
 #------
-#[8779]
+#[8809]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[877E]
+#[880E]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 79 87 00 00          # mov esi, hex0_str
+BE 09 88 00 00          # mov esi, hex0_str
 E8 FF F7 FF FF          # call console_puts
 
 # read "ex0 '
@@ -2258,7 +2307,7 @@ CD 80                   # int 80
 
 
 #------
-#[8805]
+#[8895]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2348,18 +2397,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8872]
+#[8902]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[887A]
+#[890A]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[887E]
+#[890E]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2367,7 +2416,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D 01 89 00 00   00     # cmp [enable_flush], 0
+83 3D 91 89 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2386,7 +2435,7 @@ B9 FF 07 00 00             # mov ecx, 0x000007FF
 
 # no more reading from disk - enable interrupts
 40                         # inc eax
-A3 80 7E 00 00             # mov [have_userspace], eax
+A3 1C 7F 00 00             # mov [have_userspace], eax
 FB                         # sti
 
 BA 01 00 D0 04             # mov edx, 0x04D00001
@@ -2416,8 +2465,8 @@ BE 00 04 D0 04             # mov esi, arg1
 E8 A3 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 72 88 00 00             # mov ecx, cmd_args
-BA 7A 88 00 00             # mov edx, cmd_env
+B9 02 89 00 00             # mov ecx, cmd_args
+BA 0A 89 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2428,22 +2477,22 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[8901]
+#[8991]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[8905]
+#[8995]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB A7 89 00 00           # mov ebx, str_dev_hda
+BB 37 8A 00 00           # mov ebx, str_dev_hda
 E8 D2 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 91 89 00 00           # mov esi, str_error_no_write
+BE 21 8A 00 00           # mov esi, str_error_no_write
 E8 6B F6 FF FF           # call console_puts
 
 # one space to flush last line
@@ -2499,28 +2548,53 @@ C3                       # ret
 
 
 #------
-#[8981]
+#[8A11]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8991]
+#[8A21]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[89A7]
+#[8A37]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
+#------
+#[8A40]
+#:str_e820
+#/  e  8  2  0 \0
+2F 65 38 32 30 00
+
 
 #------------------------------------------------------------
-#[89B0]
+#[8A46]
 #:internalshell
-B8 00 7C 00 00                 # mov eax, $kernel_entry
+
+# clear file name table
+BF 00 00 20 00                 # mov edi, 0x00200000
+B9 00 00 E0 00                 # mov ecx, 0x00E00000
+31 C0                          # xor eax, eax
+F3 AA                          # rep stosb
+
+# check for an E820 memory map
+A1 00 08 01 00                 # mov eax, [0x10800]
+85 C0                          # test eax, eax
+74 20                          # jz no_e820
+A3 38 00 00 01                 # mov [0x1000038], eax
+C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
+BE 40 8A 00 00                 # mov esi, str_e820
+BF 00 0C 20 00                 # mov edi, 0x200C00
+B9 06 00 00 00                 # mov ecx, 6
+F3 A4                          # rep movsb
+
+#:no_e820
+B8 00 7C 00 00                 # mov eax, &kernel_entry
 3D 00 7C 00 00                 # cmp eax, 0x00007C00
 75 0C                          # jne stage2_stdin
 
@@ -2529,8 +2603,8 @@ C7 05 00 00 00 01 08 00 00 00  # mov word [0x01000000], 0x00000008
 EB 0A                          # jmp after_set_stdin
 
 #:stage2_stdin
-# Start reading stdin from logical sector 168
-C7 05 00 00 00 01 A8 00 00 00  # mov word [0x01000000], 0x000000A8
+# Start reading stdin from logical sector 175
+C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 #:after_set_stdin
 # start at "end of sector" to trigger an initial sector read
@@ -2544,16 +2618,11 @@ B9 00 0E 00 00                 # mov ecx, 0x00000E00
 31 C0                          # xor eax, eax
 F3 AA                          # rep stosb
 
-# clear file name table
-BF 00 00 20 00                 # mov edi, 0x00200000
-B9 00 00 E0 00                 # mov ecx, 0x00E00000
-F3 AA                          # rep stosb
-
 # read from stdin
 31 DB                          # xor ebx, ebx
 
 #:process_command
-E8 86 FC FF FF                 # call read
+E8 55 FC FF FF                 # call read
 3C 00                          # cmp al, 0
 74 2E                          # je build_finished
 
@@ -2562,7 +2631,7 @@ E8 86 FC FF FF                 # call read
 75 07                          # jne check_hex0_command
 
 #:handle_src_command
-E8 BF FC FF FF                 # call src
+E8 8E FC FF FF                 # call src
 EB EC                          # jmp process_command
 
 #:check_hex0_command
@@ -2570,7 +2639,7 @@ EB EC                          # jmp process_command
 75 07                          # jne check_flush_command
 
 #:handle_hex0_command
-E8 58 FD FF FF                 # call hex0
+E8 27 FD FF FF                 # call hex0
 EB E1                          # jmp process_command
 
 #:check_flush_command
@@ -2578,40 +2647,25 @@ EB E1                          # jmp process_command
 75 0D                          # jne call_handle_other_command
 
 #:handle_flush_command
-E8 63 FC FF FF                 # call read    ; read the newline
-FF 05 01 89 00 00              # inc dword [enable_flush]
+E8 32 FC FF FF                 # call read    ; read the newline
+FF 05 91 89 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
-E8 40 FE FF FF                 # call handle_other_command
+E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 81 89 00 00                 # mov esi, str_build_finished
-E8 40 F5 FF FF                 # call console_puts
+BE 11 8A 00 00                 # mov esi, str_build_finished
+E8 0F F5 FF FF                 # call console_puts
 
-E8 B6 FE FF FF                 # call flush_disk
+E8 85 FE FF FF                 # call flush_disk
 
 #:shell_reboot
-E9 6C F5 FF FF                 # jmp reboot
+E9 3B F5 FF FF                 # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 

--- a/builder-hex0.hex2
+++ b/builder-hex0.hex2
@@ -96,7 +96,7 @@
 #                      0x100  0x100  current directory
 #                      0x200  x0E00  file descriptors 448 * 8 bytes each
 #                                    { global_file_index, current_offset }
-#    10800 -    1FFFF unused
+#    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
 #     A000 -     A1FF sector read buffer - 16bit
 #     7C00 -     8600 code
@@ -509,17 +509,69 @@ B8 01 24                # mov ax,2401h     # enable A20 line
 CD 15                   # int 15h
 
 :init_no_a20
-# start 32bit mode
-FA                      # cli
-0F 01 06 $Saved_GDT_locator # sgdt Saved_GDT_locator
-EB !past_MBR            # jmp past_MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
-90                      # nop    ; padding to align MBR
+
+# adapted from https://wiki.osdev.org/Detecting_Memory_(x86)#Getting_an_E820_Memory_Map
+# use the INT 0x15, eax=0xE820 BIOS function to get a memory map
+
+66 60                       # pushad
+66 9C                       # pushfd
+06                          # push es
+68 00 10                    # push 0x1000
+07                          # pop es
+EB !past_MBR                # jmp past_MBR
+90                          # nop    ; padding to align MBR
 # This is the DOS/MBR identifier at offset 510:
 55 AA
 :past_MBR
+66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
+26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
+BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
+66 31 ED                    # xor ebp, ebp              ; keep an entry count in bp
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; place "SMAP" into edx
+66 B8 20 E8 00 00           # mov eax, 0xE820
+26 66 C7 45 14 01 00 00 00  # mov dword ptr es:[di + 20], 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes
+CD 15                       # int 0x15
+72 !failed                  # jc short failed           ; carry set on first call means "unsupported function"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; Some BIOSes apparently trash this register?
+66 39 D0                    # cmp eax, edx              ; on success, eax must have been reset to "SMAP"
+75 !failed                  # jne short failed
+66 85 DB                    # test ebx, ebx             ; ebx = 0 implies list is only 1 entry long (worthless)
+74 !failed                  # je short failed
+EB !jmpin                   # jmp short jmpin
+:e820lp
+66 B8 20 E8 00 00           # mov eax, 0xE820           ; eax, ecx get trashed on every int 0x15 call
+26 66 C7 45 14 01 00 00 00  # mov [es:di + 20], dword 1 ; force a valid ACPI 3.X entry
+66 B9 18 00 00 00           # mov ecx, 24               ; ask for 24 bytes again
+CD 15                       # int 0x15
+72 !e820f                   # jc short e820f            ; carry set means "end of list already reached"
+66 BA 50 41 4D 53           # mov edx, 0x0534D4150      ; repair potentially trashed register
+:jmpin
+E3 !skipent                 # jcxz skipent              ; skip any 0 length entries
+80 F9 14                    # cmp cl, 20                ; got a 24 byte ACPI 3.X response?
+76 !notext                  # jbe short notext
+26 F6 45 14 01              # test byte ptr es:[di + 20], 1 ; if so: is the "ignore this data" bit clear?
+74 !skipent                 # je short skipent
+:notext
+26 66 8B 4D 08              # mov ecx, es:[di + 8]      ; get lower uint32_t of memory region length
+26 66 0B 4D 0C              # or ecx, es:[di + 12]      ; "or" it with upper uint32_t to test for zero
+74 !skipent                 # jz skipent                ; if length uint64_t is 0, skip entry
+83 C5 18                    # add bp, 24                ; got a good entry: ++count, move to next storage spot
+26 66 C7 45 FC 14 00 00 00  # mov dword ptr es:[di - 4], 20 ; set multiboot entry size
+83 C7 18                    # add di, 24
+:skipent
+66 85 DB                    # test ebx, ebx             ; if ebx resets to 0, list is complete
+75 !e820lp                  # jne short e820lp
+:e820f
+26 66 89 2E 00 08           # mov es:[0x800], ebp       ; store the structure size
+:failed
+07                          # pop es
+66 9D                       # popfd
+66 61                       # popad
+
+# start 32bit mode
+FA                      # cli
+0F 01 06 $Saved_GDT_locator # sgdt Saved_GDT_locator
 0F 01 16 $GDT_locator   # lgdt GDT_locator
 0F 20 C0                # mov eax, cr0
 66 83 C8 01             # or eax, 0x01
@@ -576,20 +628,17 @@ C3                        # ret
 CF                    # iret
 
 #----------------------------------------
-:Init_A20
-00 00
-
-#----------------------------------------
 :have_userspace
 00 00 00 00
-
-# align IDT locator to 16 byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00
 
 #----------------------------------------
 :IDT_locator_32
 FF 07        #  length
 00 00 01 00  #  IDT_start
+
+#----------------------------------------
+:Init_A20
+00 00
 
 
 #------------------------------------------------------------
@@ -666,7 +715,7 @@ A1 08 7B                  # mov ax, [0x7B08]  ; restore from above
 CB                        # retf
 
 # align IDT locator to 16-byte boundary
-00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
 
 #------
 :IDT_locator_16
@@ -1184,7 +1233,7 @@ A1 &next_filenum      # mov eax, [next_filenum]
 89 DE                 # mov esi, ebx
 
 :checkfile
-83 F8 03              # cmp eax, 3
+83 F8 02              # cmp eax, 2
 74 !not_found         # je not_found
 89 C7                 # mov edi, eax
 C1 E7 0A              # shl edi, 0x0a
@@ -2447,10 +2496,34 @@ C3                       # ret
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
+#------
+:str_e820
+#/  e  8  2  0 \0
+2F 65 38 32 30 00
+
 
 #------------------------------------------------------------
 :internalshell
-B8 &kernel_entry               # mov eax, $kernel_entry
+
+# clear file name table
+BF 00 00 20 00                 # mov edi, 0x00200000
+B9 00 00 E0 00                 # mov ecx, 0x00E00000
+31 C0                          # xor eax, eax
+F3 AA                          # rep stosb
+
+# check for an E820 memory map
+A1 00 08 01 00                 # mov eax, [0x10800]
+85 C0                          # test eax, eax
+74 !no_e820                    # jz no_e820
+A3 38 00 00 01                 # mov [0x1000038], eax
+C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
+BE &str_e820                   # mov esi, str_e820
+BF 00 0C 20 00                 # mov edi, 0x200C00
+B9 06 00 00 00                 # mov ecx, 6
+F3 A4                          # rep movsb
+
+:no_e820
+B8 &kernel_entry               # mov eax, &kernel_entry
 3D 00 7C 00 00                 # cmp eax, 0x00007C00
 75 !stage2_stdin               # jne stage2_stdin
 
@@ -2459,8 +2532,8 @@ C7 05 00 00 00 01 08 00 00 00  # mov word [0x01000000], 0x00000008
 EB !after_set_stdin            # jmp after_set_stdin
 
 :stage2_stdin
-# Start reading stdin from logical sector 168
-C7 05 00 00 00 01 A8 00 00 00  # mov word [0x01000000], 0x000000A8
+# Start reading stdin from logical sector 175
+C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 :after_set_stdin
 # start at "end of sector" to trigger an initial sector read
@@ -2472,11 +2545,6 @@ C7 05 00 00 00 01 A8 00 00 00  # mov word [0x01000000], 0x000000A8
 BF 00 02 02 00                 # mov edi, 0x00020200
 B9 00 0E 00 00                 # mov ecx, 0x00000E00
 31 C0                          # xor eax, eax
-F3 AA                          # rep stosb
-
-# clear file name table
-BF 00 00 20 00                 # mov edi, 0x00200000
-B9 00 00 E0 00                 # mov ecx, 0x00E00000
 F3 AA                          # rep stosb
 
 # read from stdin
@@ -2526,22 +2594,7 @@ E8 %flush_disk                 # call flush_disk
 E9 %reboot                     # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 


### PR DESCRIPTION
This reads the BIOS E820 memory map, and stores it as a Multiboot memory map structure, accessible as /e820,  for later use by Fiwix.