### PR TITLE
Use multi-sector reads in stage2 for faster srcfs processing

### DIFF
--- a/builder-hex0-x86-stage2.hex0
+++ b/builder-hex0-x86-stage2.hex0
@@ -123,7 +123,7 @@ EA 07 7E 00 00     # jmp far setcs
 BC 00 7B           # mov sp, 0x7B00
 FC                 # cld ; clear direction flag
 
-E9 80 01           # jmp kernel_main
+E9 90 01           # jmp kernel_main
 
 
 #------------------------
@@ -257,7 +257,9 @@ C3                   # ret
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
 56                       # push si
 BE 60 7E                 # mov si, addr_packet      ; disk address packet
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 72 21                    # jc read_error
 
 8B 3E 62 7E              # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
@@ -273,7 +275,7 @@ C1 E7 09                 # shl di, 9     ; 512 == 2^9
 01 FB                    # add bx, di
 
 85 F6                    # test si, si
-75 CA                    # jnz read_one_loop
+75 C6                    # jnz read_one_loop
 
 89 DF                    # mov di, bx
 
@@ -300,13 +302,15 @@ BE 60 7E                 # mov si, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 50 7E              # mov dl, [boot_drive]
 31 C0                    # xor ax, ax
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 5E                       # pop si
-EB 96                    # jmp read_one_loop
+EB 8E                    # jmp read_one_loop
 
 
 #------------------------
-#[7EE7]
+#[7EEF]
 #:write_sectors_16
 # inputs:
 #   si: source_addr
@@ -335,7 +339,9 @@ EB 96                    # jmp read_one_loop
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
 BE 60 7E                # mov si, addr_packet      ; disk address packet
 
+66 60                   # pushad
 CD 13                   # int 0x13
+66 61                   # popad
 72 20                   # jc write_error
 
 8B 36 62 7E             # mov si, word ptr [num_sectors_bios]  ; number of sectors actually written
@@ -350,7 +356,7 @@ C1 E6 09                # shl si, 9     ; 512 == 2^9
 01 F3                   # add bx, si
 
 85 FF                   # test di, di
-75 CC                   # jnz write_one_loop
+75 C8                   # jnz write_one_loop
 
 89 DE                   # mov si, bx
 
@@ -377,8 +383,10 @@ BF 60 7E                # mov di, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 50 7E             # mov dl, [boot_drive]
 31 C0                   # xor ax, ax
+66 60                   # pushad
 CD 13                   # int 0x13
-EB 99                   # jmp write_one_loop
+66 61                   # popad
+EB 91                   # jmp write_one_loop
 
 
 # align GDT to 16 byte boundary
@@ -387,7 +395,7 @@ EB 99                   # jmp write_one_loop
 #---------------------------------------------
 # The Global Descriptor Table for 32 bit mode.
 #---------------------------------------------
-#[7F60]
+#[7F70]
 #:GDT_start
 00 00 00 00 00 00 00 00
 
@@ -436,20 +444,20 @@ FF FF # limit 0:15
 00    # base 24:31
 
 #------
-#[7F88]
+#[7F98]
 #:GDT_locator
 27 00        #  length
-60 7F 00 00  #  GDT_start
+70 7F 00 00  #  GDT_start
 
 #------
-#[7F8E]
+#[7F9E]
 #:Saved_GDT_locator
 00 00        #  length
 00 00 00 00  #  GDT_start
 
 
 #------------------------
-#[7F94]
+#[7FA4]
 #:kernel_main
 # inputs:
 #   dl: boot_drive
@@ -465,7 +473,7 @@ B8 00 7E                # mov ax, $kernel_entry
 BF 00 7E                # mov di, 0x7E00   ; place remaining code after MBR in memory
 B8 07 00                # mov ax, 7        ; num_sectors = 7
 66 B9 01 00 00 00       # mov ecx, 1       ; starting logical sector = 1
-E8 C1 FE                # call read_sectors_16
+E8 B1 FE                # call read_sectors_16
 
 #:after_load
 # check if A20 line needs handling
@@ -511,8 +519,13 @@ FB                      # sti
 1F                      # pop ds
 9D                      # popf
 
-A3 26 81                # mov word ptr [Init_A20], ax
+A3 36 81                # mov word ptr [Init_A20], ax
 85 C0                   # test ax, ax
+EB 03                   # jmp past_MBR
+90                      # nop    ; padding to align MBR
+# This is the DOS/MBR identifier at offset 510:
+55 AA
+#:past_MBR
 75 05                   # jnz init_no_a20
 
 # enable Gate A20
@@ -529,11 +542,6 @@ CD 15                   # int 15h
 06                          # push es
 68 00 10                    # push 0x1000
 07                          # pop es
-EB 03                       # jmp past_MBR
-90                          # nop    ; padding to align MBR
-# This is the DOS/MBR identifier at offset 510:
-55 AA
-#:past_MBR
 66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
 26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
 BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
@@ -582,15 +590,15 @@ E3 27                       # jcxz skipent              ; skip any 0 length entr
 
 # start 32bit mode
 FA                      # cli
-0F 01 06 8E 7F              # sgdt Saved_GDT_locator
-0F 01 16 88 7F          # lgdt GDT_locator
+0F 01 06 9E 7F              # sgdt Saved_GDT_locator
+0F 01 16 98 7F          # lgdt GDT_locator
 0F 20 C0                # mov eax, cr0
 66 83 C8 01             # or eax, 0x01
 0F 22 C0                # mov cr0, eax
-EA B2 80 08 00          # jmp setup_32bit     ; sets CS
+EA C2 80 08 00          # jmp setup_32bit     ; sets CS
 
 #------
-#[80B2]
+#[80C2]
 #:setup_32bit
 66 B8 10 00             # mov ax, 0x0010      ; data descriptor
 8E D8                   # mov ds, ax
@@ -606,28 +614,28 @@ E9 75 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
-#[80D1]
+#[80E1]
 #:setup_int_handlers
 53                        # push ebx
 
 # handle the timer interrupt 08
 BB 40 00 01 00            # mov ebx, &interrupt_table[08]
-66 C7 03 1B 81                       # mov word [ebx + 0], low_address stub_interrupt_handler
+66 C7 03 2B 81                       # mov word [ebx + 0], low_address stub_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # handle int 80
 BB 00 04 01 00            # mov ebx, &interrupt_table[80]
-66 C7 03 5B 82                       # mov word [ebx + 0], low_address syscall_interrupt_handler
+66 C7 03 6B 82                       # mov word [ebx + 0], low_address syscall_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # load the interrupt table
 FA                        # cli
-0F 01 1D 20 81 00 00      # lidt IDT_locator_32
-8B 1D 1C 81 00 00         # mov ebx, [have_userspace]
+0F 01 1D 30 81 00 00      # lidt IDT_locator_32
+8B 1D 2C 81 00 00         # mov ebx, [have_userspace]
 85 DB                     # test ebx
 74 01                     # jz before_userspace
 FB                        # sti
@@ -637,23 +645,23 @@ C3                        # ret
 
 
 #----------------------------------------
-#[811B]
+#[812B]
 #:stub_interrupt_handler
 CF                    # iret
 
 #----------------------------------------
-#[811C]
+#[812C]
 #:have_userspace
 00 00 00 00
 
 #----------------------------------------
-#[8120]
+#[8130]
 #:IDT_locator_32
 FF 07        #  length
 00 00 01 00  #  IDT_start
 
 #----------------------------------------
-#[8126]
+#[8136]
 #:Init_A20
 00 00
 
@@ -673,7 +681,7 @@ FF 07        #  length
 # 7B00  <- top of real mode stack
 
 #----------------------------------------
-#[8128]
+#[8138]
 #:enter_16bit_real
 FA                        # cli
 A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these locally
@@ -684,9 +692,9 @@ A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these lo
 # The following far jump sets CS to a 16-bit protected mode selector
 # and the segment registers are also set to 16-bit protected mode selectors.
 # This is done prior to entering real mode.
-EA 42 81 00 00  18 00 # jmp 0x18:setup_16bit
+EA 52 81 00 00  18 00 # jmp 0x18:setup_16bit
 #------
-#[8142]
+#[8152]
 #:setup_16bit
 B8 20 00                  # mov ax, 0x0020
 8E D0                     # mov ss, ax
@@ -700,9 +708,9 @@ BC 00 7B                  # mov sp, 0x7B00
 0F 22 C0                  # mov cr0, eax
 # The following far jump sets CS to a 16-bit real mode segment
 # and the segment registers are also set to real mode segments.
-EA 61 81 00 00            # jmp 0000:XXXX  real_mode
+EA 71 81 00 00            # jmp 0000:XXXX  real_mode
 #------
-#[8161]
+#[8171]
 #:real_mode
 B8 00 00                  # mov ax, 0x0
 8E D8                     # mov ds, ax
@@ -712,12 +720,12 @@ B8 00 00                  # mov ax, 0x0
 8E C0                     # mov es, ax
 BC 00 7B                  # mov sp, 0x7B00
 FA                        # cli
-0F 01 1E A0 81            # lidt IDT_locator_16
-0F 01 16 8E 7F              # lgdt Saved_GDT_locator
+0F 01 1E B0 81            # lidt IDT_locator_16
+0F 01 16 9E 7F              # lgdt Saved_GDT_locator
 FB                        # sti
 
 # Reset Gate A20 if needed
-A1 26 81                  # mov ax, word ptr [Init_A20]
+A1 36 81                  # mov ax, word ptr [Init_A20]
 85 C0                     # test ax, ax
 75 05                     # jnz enter_no_a20
 B8 00 24                  # mov ax,2400h     # disable A20 line
@@ -738,17 +746,17 @@ CB                        # retf
 00 00 00 00 00 00 00 00 00 00 00 00
 
 #------
-#[81A0]
+#[81B0]
 #:IDT_locator_16
 FF 03
 00 00 00 00
 
 
 #----------------------------------------
-#[81A6]
+#[81B6]
 #:resume_32bit_mode
 50                           # push ax
-A1 26 81                     # mov ax, word ptr [Init_A20]
+A1 36 81                     # mov ax, word ptr [Init_A20]
 85 C0                        # test ax, ax
 75 05                        # jnz exit_no_a20
 
@@ -763,14 +771,14 @@ A3 08 7B                     # mov [0x7B08], ax  ; preserve, they might be retur
 89 16 14 7B                  # mov [0x7B14], dx
 5A                           # pop dx      ; carry the return IP in dx
 58                           # pop ax      ; CS
-0F 01 06 8E 7F               # sgdt Saved_GDT_locator
-0F 01 16 88 7F               # lgdt GDT_locator
+0F 01 06 9E 7F               # sgdt Saved_GDT_locator
+0F 01 16 98 7F               # lgdt GDT_locator
 0F 20 C0                     # mov eax, cr0
 66 83 C8 01                  # or eax, 0x01         ; enable protected mode
 0F 22 C0                     # mov cr0, eax
-EA D7 81 08 00               # jmp restore_32bit
+EA E7 81 08 00               # jmp restore_32bit
 #------
-#[81D7]
+#[81E7]
 #:restore_32bit
 B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E D8                        # mov ds, eax
@@ -791,26 +799,26 @@ C3                           # ret
 
 
 #------------------------
-#[81FE]
+#[820E]
 #:console_putc
 #
 E8 25 FF FF FF          # call enter_16bit_real
-E8 0E FC                # call console_putc_16(al)
-9A A6 81 00 00          # call resume_32bit_mode
+E8 FE FB                # call console_putc_16(al)
+9A B6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[820C]
+#[821C]
 #:console_put_hex
 E8 17 FF FF FF          # call enter_16bit_real
-E8 16 FC                # call console_put_hex_16(al)
-9A A6 81 00 00          # call resume_32bit_mode
+E8 06 FC                # call console_put_hex_16(al)
+9A B6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[821A]
+#[822A]
 #:console_puts
 # inputs
 #   ds:si: string to print
@@ -832,7 +840,7 @@ C3                      # ret
 
 
 #------------------------
-#[8234]
+#[8244]
 #:read_sectors
 # inputs:
 #   di: dest_addr
@@ -840,13 +848,13 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 EF FE FF FF          # call enter_16bit_real
-E8 34 FC                # call read_sectors_16
-9A A6 81 00 00          # call resume_32bit_mode
+E8 24 FC                # call read_sectors_16
+9A B6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[8242]
+#[8252]
 #:write_sectors
 # inputs:
 #   si: source_addr
@@ -854,12 +862,12 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 E1 FE FF FF          # call enter_16bit_real
-E8 9D FC                # call write_sectors_16
-9A A6 81 00 00          # call resume_32bit_mode
+E8 95 FC                # call write_sectors_16
+9A B6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
 #------------------------
-#[8250]
+#[8260]
 #:reboot
 E8 D3 FE FF FF          # call enter_16bit_real
 FA                      # cli
@@ -867,7 +875,7 @@ EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 
 
 #------------------------
-#[825B]
+#[826B]
 #:syscall_interrupt_handler
 #
 3C 01                             # cmp al, 1
@@ -967,17 +975,17 @@ CF                                # iret
 
 
 #------
-#[82F3]
+#[8303]
 #:next_filenum
 04 00 00 00
 
 #------
-#[82F7]
+#[8307]
 #:next_file_address
 00 00 00 54
 
 #----------------------------------------
-#[82FB]
+#[830B]
 #:handle_syscall_open
 # inputs:
 #   ebx: filename
@@ -1032,7 +1040,7 @@ E9 80 00 00 00              # jmp open_finish_fail
 # copy filename to new slot
 89 DE                       # mov esi, ebx
 BF 00 00 20 00              # mov edi, 0x0200000
-A1 F3 82 00 00              # mov eax, [next_filenum]
+A1 03 83 00 00              # mov eax, [next_filenum]
 C1 E0 0A                    # shl eax, 0a
 01 C7                       # add edi, eax
 B9 00 04 00 00              # mov ecx, 0x0000400
@@ -1040,18 +1048,18 @@ F3 A4                       # rep movsb
 
 # set address of file
 BF 00 00 00 01              # mov edi, 0x01000000           ; pfile_descriptor = &file_descriptor[0]
-A1 F3 82 00 00              # mov eax, [next_filenum]
+A1 03 83 00 00              # mov eax, [next_filenum]
 C1 E0 04                    # shl eax, 04
 01 C7                       # add edi, eax                  ; pfile_descriptor += sizeof(file_descriptor) * next_filenum
-8B 0D F7 82 00 00           # mov ecx, [next_file_address]
+8B 0D 07 83 00 00           # mov ecx, [next_file_address]
 
 89 4F 04                    # mov [edi+4], ecx              ; pfile_descriptor->file_addr = ecx
 
 31 C0                       # xor eax, eax
 89 47 08                    # mov [edi+8], eax              ; pfile_descriptor->length = 0
 
-A1 F3 82 00 00              # mov eax, [next_filenum]       ; return next_filenum
-FF 05 F3 82 00 00           # inc [next_filenum]
+A1 03 83 00 00              # mov eax, [next_filenum]       ; return next_filenum
+FF 05 03 83 00 00           # inc [next_filenum]
 EB 16                       # jmp syscall_open_finish
 
 #:open_read
@@ -1066,7 +1074,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 6E 86 00 00           # mov esi, [next_process_num]
+8B 35 7E 86 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1088,7 +1096,7 @@ EB F4                       # jmp find_slot_loop
 89 4E 04                    # mov [esi+0x4], ecx
 
 #--------
-#[83B8]
+#[83C8]
 #:open_finish_fail
 
 5F                          # pop edi
@@ -1099,13 +1107,13 @@ C3                          # ret
 
 
 #----------------------------------------
-#[83BD]
+#[83CD]
 #:handle_syscall_close
 # inputs:
 #   ebx: fd
 
 57                          # push edi
-8B 3D 6E 86 00 00           # mov edi, [next_process_num]
+8B 3D 7E 86 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1116,7 +1124,7 @@ C3                          # ret
 
 
 #----------------------------------------
-#[83D5]
+#[83E5]
 #:absolute_path
 # inputs:
 #   ebx: path
@@ -1136,7 +1144,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 6E 86 00 00             # mov esi, [next_process_num]
+8B 35 7E 86 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1253,7 +1261,7 @@ C3                            # ret
 
 
 #----------------------------------------
-#[8472]
+#[8482]
 #:find_file
 # inputs:
 #   ebx: file_name
@@ -1265,7 +1273,7 @@ C3                            # ret
 56                    # push esi
 57                    # push edi
 
-A1 F3 82 00 00        # mov eax, [next_filenum]
+A1 03 83 00 00        # mov eax, [next_filenum]
 48                    # dec eax
 89 DE                 # mov esi, ebx
 
@@ -1292,14 +1300,14 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[84A2]
+#[84B2]
 #:fd_to_file_index
 # inputs:
 #   ebx: file descriptor number
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D 6E 86 00 00        # mov edi, [next_process_num]
+8B 3D 7E 86 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1309,7 +1317,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[84B8]
+#[84C8]
 #:handle_syscall_read
 # inputs:
 #   ecx: *return_char
@@ -1386,7 +1394,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 6E 86 00 00        # mov esi, [next_process_num]
+8B 35 7E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1418,11 +1426,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8566]
+#[8576]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1457,7 +1465,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8595]
+#[85A5]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1491,7 +1499,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D 6E 86 00 00         # mov ecx, [next_process_num]
+8B 0D 7E 86 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1518,7 +1526,7 @@ FF 01                     # inc long [ecx]       ; current_offset++
 3B 43 08                  # cmp eax, [ebx+0x8]
 7E 09                     # jle skip_lengthen
 FF 43 08                  # inc long [ebx+0x8]   ; file_length++
-FF 05 F7 82 00 00         # inc long [next_file_address]
+FF 05 07 83 00 00         # inc long [next_file_address]
 #:skip_lengthen
 58                        # pop eax
 40                        # inc eax              ; num_written++
@@ -1534,12 +1542,12 @@ C3                        # ret
 
 
 #------
-#[8600]
+#[8610]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8604]
+#[8614]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1548,7 +1556,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1561,12 +1569,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 00 86 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 10 86 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 00 86 00 00                 # add [next_save_process_address], ecx
+01 0D 10 86 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1581,7 +1589,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 00 86 00 00                 # add [next_save_process_address], ecx
+01 0D 10 86 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1595,12 +1603,12 @@ C3                    # ret
 
 
 #------
-#[866E]
+#[867E]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[8672]
+#[8682]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1608,7 +1616,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1628,19 +1636,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 00 86 00 00                 # mov edi, [next_save_process_address]
+8B 3D 10 86 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1690,13 +1698,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 00 86 00 00                 # mov [next_save_process_address], edi
+89 3D 10 86 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1783,7 +1791,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 6E 86 00 00           # inc [next_process_num]
+FF 05 7E 86 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1799,7 +1807,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[87AD]
+#[87BD]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
@@ -1820,7 +1828,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D 6E 86 00 00           # mov edi, [next_process_num]
+8B 3D 7E 86 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1854,11 +1862,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8800]
+#[8810]
 #:handle_syscall_exit
-A1 6E 86 00 00        # mov eax, [next_process_num]
+A1 7E 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 6E 86 00 00        # mov [next_process_num], eax
+A3 7E 86 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1878,7 +1886,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 00 86 00 00                 # mov [next_save_process_address], esi
+89 35 10 86 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1901,9 +1909,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[8854]
+#[8864]
 #:handle_syscall_waitpid
-8B 35 6E 86 00 00        # mov esi, [next_process_num]
+8B 35 7E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1915,7 +1923,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[886E]
+#[887E]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1926,7 +1934,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 6E 86 00 00           # mov esi, [next_process_num]
+8B 35 7E 86 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1967,7 +1975,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[88B4]
+#[88C4]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
@@ -1982,7 +1990,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[88C6]
+#[88D6]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
@@ -1999,7 +2007,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[88DA]
+#[88EA]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -2010,7 +2018,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 6E 86 00 00        # mov esi, [next_process_num]
+8B 35 7E 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -2037,7 +2045,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8907]
+#[8917]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2071,19 +2079,19 @@ C3                    # ret
 
 
 #------
-#[8922]
+#[8932]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8924]
+#[8934]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 22 89 00 00        # mov ecx, io_char
+B9 32 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2092,7 +2100,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 22 89 00 00        # mov al, io_char
+A0 32 89 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2102,16 +2110,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8947]
+#[8957]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 22 89 00 00        # mov io_char, al
+A2 32 89 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 22 89 00 00        # mov ecx, io_char
+B9 32 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2123,7 +2131,7 @@ C3                    # ret
 
 
 #------
-#[8966]
+#[8976]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2137,7 +2145,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[896A]
+#[897A]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2146,7 +2154,7 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE 66 89 00 00          # mov esi, string_src
+BE 76 89 00 00          # mov esi, string_src
 E8 A0 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
@@ -2230,19 +2238,19 @@ C3                      # ret
 
 
 #------
-#[8A09]
+#[8A19]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[8A0E]
+#[8A1E]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 09 8A 00 00          # mov esi, hex0_str
+BE 19 8A 00 00          # mov esi, hex0_str
 E8 FF F7 FF FF          # call console_puts
 
 # read "ex0 '
@@ -2307,7 +2315,7 @@ CD 80                   # int 80
 
 
 #------
-#[8A95]
+#[8AA5]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2397,18 +2405,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8B02]
+#[8B12]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[8B0A]
+#[8B1A]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[8B0E]
+#[8B1E]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2416,7 +2424,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D 91 8B 00 00   00     # cmp [enable_flush], 0
+83 3D A1 8B 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2435,7 +2443,7 @@ B9 FF 07 00 00             # mov ecx, 0x000007FF
 
 # no more reading from disk - enable interrupts
 40                         # inc eax
-A3 1C 81 00 00             # mov [have_userspace], eax
+A3 2C 81 00 00             # mov [have_userspace], eax
 FB                         # sti
 
 BA 01 00 D0 04             # mov edx, 0x04D00001
@@ -2465,8 +2473,8 @@ BE 00 04 D0 04             # mov esi, arg1
 E8 A3 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 02 8B 00 00             # mov ecx, cmd_args
-BA 0A 8B 00 00             # mov edx, cmd_env
+B9 12 8B 00 00             # mov ecx, cmd_args
+BA 1A 8B 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2477,22 +2485,22 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[8B91]
+#[8BA1]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[8B95]
+#[8BA5]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB 37 8C 00 00           # mov ebx, str_dev_hda
+BB 47 8C 00 00           # mov ebx, str_dev_hda
 E8 D2 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 21 8C 00 00           # mov esi, str_error_no_write
+BE 31 8C 00 00           # mov esi, str_error_no_write
 E8 6B F6 FF FF           # call console_puts
 
 # one space to flush last line
@@ -2548,32 +2556,32 @@ C3                       # ret
 
 
 #------
-#[8C11]
+#[8C21]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8C21]
+#[8C31]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[8C37]
+#[8C47]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
 #------
-#[8C40]
+#[8C50]
 #:str_e820
 #/  e  8  2  0 \0
 2F 65 38 32 30 00
 
 
 #------------------------------------------------------------
-#[8C46]
+#[8C56]
 #:internalshell
 
 # clear file name table
@@ -2588,7 +2596,7 @@ A1 00 08 01 00                 # mov eax, [0x10800]
 74 20                          # jz no_e820
 A3 38 00 00 01                 # mov [0x1000038], eax
 C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
-BE 40 8C 00 00                 # mov esi, str_e820
+BE 50 8C 00 00                 # mov esi, str_e820
 BF 00 0C 20 00                 # mov edi, 0x200C00
 B9 06 00 00 00                 # mov ecx, 6
 F3 A4                          # rep movsb
@@ -2648,7 +2656,7 @@ EB E1                          # jmp process_command
 
 #:handle_flush_command
 E8 32 FC FF FF                 # call read    ; read the newline
-FF 05 91 8B 00 00              # inc dword [enable_flush]
+FF 05 A1 8B 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
@@ -2656,7 +2664,7 @@ E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 11 8C 00 00                 # mov esi, str_build_finished
+BE 21 8C 00 00                 # mov esi, str_build_finished
 E8 0F F5 FF FF                 # call console_puts
 
 E8 85 FE FF FF                 # call flush_disk
@@ -2666,7 +2674,6 @@ E9 3B F5 FF FF                 # jmp reboot
 
 # sector padding
 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/builder-hex0-x86-stage2.hex0
+++ b/builder-hex0-x86-stage2.hex0
@@ -64,7 +64,7 @@
 
 #------------------------------------------------------------
 # Memory:
-# 54000000 - BFFFFFFF files (~1812MB)
+# 54000000 - BBFFFFFF files (~1744MB)
 # 30000000 - 53FFFFFF saved processes (~604MB)
 # 08048000 - 2FFFFFFF current running process (~670MB)
 # 01080000 - 08000000 32 bit stack (117MB)
@@ -75,10 +75,11 @@
 #   201800 -   FFFFFF file names 6..14335
 #   201400 -   2017FF file name 5
 #   201000 -   2013FF file name 4
-#   100000 -   200FF0 unused
-#    9FC00 -    FFFFF BIOS
-#    40200 -    9FBFF scratch buffer
-#    40000 -    401FF stdin device buffer
+#   200C00 -   200FFF file name 3 ("/e820")
+#   100000 -   200BF0 unused
+#    80000 -    FFFFF BIOS
+#    50000 -    7FFFF scratch buffer
+#    40000 -    4FFFF stdin device buffer
 #    20000 -    3FFFF process descriptors ( 16 * 4096 bytes each)
 #                      offset len    description
 #                      0x000  0x004  process address
@@ -98,8 +99,8 @@
 #                                    { global_file_index, current_offset }
 #    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
-#     A000 -     A1FF sector read buffer - 16bit
-#     7C00 -     8600 code
+#     8E00 -     FFFF unused
+#     7C00 -     8DFF code
 #     7B00 -     7BFF Saved 32 bit registers while in 16 bit mode
 #   < 7B00            real mode stack
 #------------------------------------------------------------
@@ -218,11 +219,11 @@ C3                   # ret
 #:addr_packet
 10 00
 #:num_sectors_bios
-01 00
+40 00
 #:dest_offset
 00 00
 #:dest_segment
-00 00
+00 40
 #:starting_lba
 00 00 00 00 00 00 00 00
 #:end_addr_packet
@@ -231,27 +232,24 @@ C3                   # ret
 #[7E70]
 #:read_sectors_16
 # inputs:
-#   di: dest_addr
+#   edi: dest_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   di: next byte to write to
+#   edi: next byte to write to
 #   ecx: next disk sector to read from
 #
 50                       # push ax
-53                       # push bx
+66 53                    # push ebx
 56                       # push si
 
-1E                       # push ds
-5B                       # pop bx
-89 1E 66 7E              # mov word ptr [dest_segment], bx
 89 C6                    # mov si, ax      ; si=num_sectors
-89 FB                    # mov bx, di      ; int 13 writes to bx
+66 89 FB                 # mov ebx, edi      ; int 13 writes to bx
 
 #:read_one_loop
 89 36 62 7E              # mov word ptr [num_sectors_bios], si
-89 1E 64 7E              # mov word ptr [dest_offset], bx
+66 89 1E 64 7E           # mov dword ptr [dest_offset], ebx
 66 89 0E 68 7E           # mov dword ptr [starting_lba], ecx
 8A 16 50 7E              # mov dl, [boot_drive]
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
@@ -260,27 +258,27 @@ BE 60 7E                 # mov si, addr_packet      ; disk address packet
 66 60                    # pushad
 CD 13                    # int 0x13
 66 61                    # popad
-72 21                    # jc read_error
+72 25                    # jc read_error
 
 8B 3E 62 7E              # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
 85 FF                    # test di, di
-74 19                    # jz read_error
+74 1D                    # jz read_error
 
 # we read some sectors, advance
 5E                       # pop si
 29 FE                    # sub si, di    ; num_sectors -= num_sectors_bios
 66 0F B7 C7              # movzx eax, di
 66 01 C1                 # add ecx, eax
-C1 E7 09                 # shl di, 9     ; 512 == 2^9
-01 FB                    # add bx, di
+66 C1 E0 09              # shl eax, 9    ; 512 == 2^9
+66 01 C3                 # add ebx, eax
 
 85 F6                    # test si, si
-75 C6                    # jnz read_one_loop
+75 C3                    # jnz read_one_loop
 
-89 DF                    # mov di, bx
+66 89 DF                 # mov edi, ebx
 
 5E                       # pop si
-5B                       # pop bx
+66 5B                    # pop ebx
 58                       # pop ax
 C3                       # retf
 
@@ -306,34 +304,31 @@ BE 60 7E                 # mov si, addr_packet      ; disk address packet
 CD 13                    # int 0x13
 66 61                    # popad
 5E                       # pop si
-EB 8E                    # jmp read_one_loop
+EB 89                    # jmp read_one_loop
 
 
 #------------------------
-#[7EEF]
+#[7EF0]
 #:write_sectors_16
 # inputs:
-#   si: source_addr
+#   esi: source_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   si: next byte to read from
+#   esi: next byte to read from
 #   ecx: next disk sector to write to
 #
 50                      # push ax
-53                      # push bx
+66 53                   # push ebx
 57                      # push di
 
-1E                      # push ds
-5B                      # pop bx
-89 1E 66 7E             # mov word ptr [dest_segment], bx
 89 C7                   # mov di, ax      ; di=num_sectors
-89 F3                   # mov bx, si      ; int 13 reads from [bx]
+66 89 F3                # mov ebx, esi      ; int 13 reads from [bx]
 
 #:write_one_loop
 89 3E 62 7E             # mov word ptr [num_sectors_bios], di
-89 1E 64 7E             # mov word ptr [dest_offset], bx
+66 89 1E 64 7E          # mov dword ptr [dest_offset], ebx
 66 89 0E 68 7E          # mov dword ptr [starting_lba], ecx
 8A 16 50 7E             # mov dl, [boot_drive]
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
@@ -342,26 +337,26 @@ BE 60 7E                # mov si, addr_packet      ; disk address packet
 66 60                   # pushad
 CD 13                   # int 0x13
 66 61                   # popad
-72 20                   # jc write_error
+72 24                   # jc write_error
 
 8B 36 62 7E             # mov si, word ptr [num_sectors_bios]  ; number of sectors actually written
 85 F6                   # test si, si
-74 18                   # jz write_error
+74 1C                   # jz write_error
 
 # we wrote some sectors, advance
 29 F7                   # sub di, si    ; num_sectors -= num_sectors_bios
 66 0F B7 C6             # movzx eax, si
 66 01 C1                # add ecx, eax
-C1 E6 09                # shl si, 9     ; 512 == 2^9
-01 F3                   # add bx, si
+66 C1 E0 09             # shl eax, 9    ; 512 == 2^9
+66 01 C3                # add ebx, eax
 
 85 FF                   # test di, di
-75 C8                   # jnz write_one_loop
+75 C5                   # jnz write_one_loop
 
-89 DE                   # mov si, bx
+66 89 DE                # mov esi, ebx
 
 5F                      # pop di
-5B                      # pop bx
+66 5B                   # pop ebx
 58                      # pop ax
 C3                      # retf
 
@@ -386,11 +381,11 @@ BF 60 7E                # mov di, addr_packet      ; disk address packet
 66 60                   # pushad
 CD 13                   # int 0x13
 66 61                   # popad
-EB 91                   # jmp write_one_loop
+EB 8C                   # jmp write_one_loop
 
 
 # align GDT to 16 byte boundary
-00 00 00 00 00
+00 00 00
 
 #---------------------------------------------
 # The Global Descriptor Table for 32 bit mode.
@@ -610,7 +605,7 @@ BD 00 00 00 08          # mov ebp, 0x08000000
 89 EC                   # mov esp, ebp
 
 E8 05 00 00 00          # call setup_int_handlers
-E9 75 0B 00 00          # jmp internalshell
+E9 64 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
@@ -862,7 +857,7 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 E1 FE FF FF          # call enter_16bit_real
-E8 95 FC                # call write_sectors_16
+E8 96 FC                # call write_sectors_16
 9A B6 81 00 00          # call resume_32bit_mode
 C3                      # ret
 
@@ -880,13 +875,13 @@ EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 #
 3C 01                             # cmp al, 1
 75 06                             # jne check_fork
-E8 9C 05 00 00                    # call handle_syscall_exit
+E8 8B 05 00 00                    # call handle_syscall_exit
 CF                                # iret
 
 #:check_fork
 3C 02                             # cmp al, 2
 75 06                             # jne check_read
-E8 96 03 00 00                    # call handle_syscall_fork
+E8 85 03 00 00                    # call handle_syscall_fork
 CF                                # iret
 
 #:check_read
@@ -898,7 +893,7 @@ CF                                # iret
 #:check_write
 3C 04                             # cmp al, 4
 75 06                             # jne check_open
-E8 13 03 00 00                    # call handle_syscall_write
+E8 02 03 00 00                    # call handle_syscall_write
 CF                                # iret
 
 #:check_open
@@ -916,43 +911,43 @@ CF                                # iret
 #:check_waitpid
 3C 07                             # cmp eax, 7
 75 06                             # jne check_execve
-E8 B4 05 00 00                    # call handle_syscall_waitpid
+E8 A3 05 00 00                    # call handle_syscall_waitpid
 CF                                # iret
 
 #:check_execve
 3C 0B                             # cmp eax, B
 75 06                             # jne check_chdir
-E8 C8 03 00 00                    # call handle_syscall_execve
+E8 B7 03 00 00                    # call handle_syscall_execve
 CF                                # iret
 
 #:check_chdir
 3C 0C                             # cmp al, C
 75 06                             # jne check_lseek
-E8 F9 04 00 00                    # call handle_syscall_chdir
+E8 E8 04 00 00                    # call handle_syscall_chdir
 CF                                # iret
 
 #:check_lseek
 3C 13                             # cmp al, 0x13
 75 06                             # jne check_brk
-E8 B0 05 00 00                    # call handle_syscall_lseek
+E8 9F 05 00 00                    # call handle_syscall_lseek
 CF                                # iret
 
 #:check_brk
 3C 2D                             # cmp al, 2D
 75 06                             # jne check_access
-E8 9E 02 00 00                    # call handle_syscall_brk
+E8 8D 02 00 00                    # call handle_syscall_brk
 CF                                # iret
 
 #:check_access
 3C 21                             # cmp al, 0x21
 75 06                             # jne check_mkdir
-E8 E2 05 00 00                    # call handle_syscall_access
+E8 D1 05 00 00                    # call handle_syscall_access
 CF                                # iret
 
 #:check_mkdir
 3C 27                             # cmp al, 0x27
 75 06                             # jne check_wait4
-E8 EA 05 00 00                    # call handle_syscall_mkdir
+E8 D9 05 00 00                    # call handle_syscall_mkdir
 CF                                # iret
 
 #:check_wait4
@@ -965,7 +960,7 @@ CF                                # iret
 #:check_getcwd
 3C B7                             # cmp al, 0xB7
 75 06                             # jne syscall_ok
-E8 EB 05 00 00                    # call handle_syscall_getcwd
+E8 DA 05 00 00                    # call handle_syscall_getcwd
 CF                                # iret
 
 #:syscall_ok
@@ -1074,7 +1069,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 7E 86 00 00           # mov esi, [next_process_num]
+8B 35 6D 86 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1113,7 +1108,7 @@ C3                          # ret
 #   ebx: fd
 
 57                          # push edi
-8B 3D 7E 86 00 00           # mov edi, [next_process_num]
+8B 3D 6D 86 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1136,7 +1131,7 @@ C3                          # ret
 56                            # push esi
 57                            # push edi
 
-BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
+BF 00 00 05 00                # mov edi, 0x00050000      ; scratch buffer
 57                            # push edi
 
 # if absolute path, skip prefixing current directory
@@ -1144,7 +1139,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 7E 86 00 00             # mov esi, [next_process_num]
+8B 35 6D 86 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1283,7 +1278,7 @@ A1 03 83 00 00        # mov eax, [next_filenum]
 89 C7                 # mov edi, eax
 C1 E7 0A              # shl edi, 0x0a
 81 C7 00 00 20 00     # add edi, 0x0200000
-E8 74 04 00 00        # call strcmp
+E8 63 04 00 00        # call strcmp
 74 08                 # je find_file_finish
 48                    # dec eax
 EB E6                 # jmp checkfile
@@ -1307,7 +1302,7 @@ C3                    # ret
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D 7E 86 00 00        # mov edi, [next_process_num]
+8B 3D 6D 86 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1338,7 +1333,7 @@ C3                      # ret
 
 51                      # push ecx   ; we need this later to return char
 83 FB 00                # cmp ebx, 0
-75 55                   # jne read_memfile
+75 44                   # jne read_memfile
 
 # stdin disk position is stored in fd 0
 # get current position
@@ -1348,26 +1343,20 @@ BB 00 00 00 01          # mov ebx, 0x01000000
 66 8B 43 04             # mov ax, [ebx+4]
 
 #end of sector?
-66 3D FF 01             # cmp ax, 0x01ff
+66 3D FF 7F             # cmp ax, 0x7fff
 74 04                   # je read_next_sector
 
 #:nextchar
 66 40                   # inc ax
-EB 24                   # jmp getchar
+EB 13                   # jmp getchar
 
 #:read_next_sector
-BF 00 A0 00 00          # mov edi, 0x000A000
-B8 01 00 00 00          # mov eax, 0x0001   ; num_sectors = 1
+BF 00 00 00 40          # mov edi, 0x4000:0000 ; addr 0x40000
+B8 40 00 00 00          # mov eax, 0x0040   ; num_sectors = 64
 E8 44 FD FF FF          # call read_sectors
 # save new location and offset
 89 0B                   # mov [ebx], ecx
 31 C0                   # xor eax, eax
-
-# move block to device buffer
-BE 00 A0 00 00           # mov esi, 0x000A000
-BF 00 00 04 00           # mov edi, 0x0040000
-B9 00 02 00 00           # mov ecx, 0x0000200
-F3 A4                    # rep movsb
 
 #:getchar
 66 A3 04 00 00 01        # mov [0x01000004], ax
@@ -1381,7 +1370,7 @@ EB 41                    # jmp syscall_read_finish
 
 #:read_memfile
 89 D8                    # mov eax, ebx           ; eax = fd
-E8 7C FF FF FF           # call fd_to_file_index   ; ebx = global file index
+E8 8D FF FF FF           # call fd_to_file_index   ; ebx = global file index
 # get pointer to global file
 BE 00 00 00 01           # mov esi, 0x01000000    ; pfile_descriptor = &file_descriptor[0]
 C1 E3 04                 # shl ebx, 04
@@ -1394,7 +1383,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 7E 86 00 00        # mov esi, [next_process_num]
+8B 35 6D 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1426,11 +1415,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8576]
+#[8565]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1465,7 +1454,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[85A5]
+#[8594]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1487,7 +1476,7 @@ C3                    # ret
 74 57                     # jz syscall_write_finish
 50                        # push eax                ; save num_written
 8A 01                     # mov al, [ecx]
-E8 52 FC FF FF            # call console_putc
+E8 63 FC FF FF            # call console_putc
 58                        # pop eax                 ; restore num_written
 
 40                        # inc eax                 ; num_written++
@@ -1499,7 +1488,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D 7E 86 00 00         # mov ecx, [next_process_num]
+8B 0D 6D 86 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1509,7 +1498,7 @@ C1 E3 03                  # shl ebx, 3
 5B                        # pop ebx
 
 # lookup global file index from file descriptor
-E8 D2 FE FF FF            # call fd_to_file_index
+E8 E3 FE FF FF            # call fd_to_file_index
 C1 E3 04                  # shl ebx, 04
 81 C3 00 00 00 01         # add ebx, 0x01000000     ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
@@ -1542,12 +1531,12 @@ C3                        # ret
 
 
 #------
-#[8610]
+#[85FF]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8614]
+#[8603]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1556,7 +1545,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1569,12 +1558,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 10 86 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 FF 85 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 10 86 00 00                 # add [next_save_process_address], ecx
+01 0D FF 85 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1589,7 +1578,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 10 86 00 00                 # add [next_save_process_address], ecx
+01 0D FF 85 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1603,12 +1592,12 @@ C3                    # ret
 
 
 #------
-#[867E]
+#[866D]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[8682]
+#[8671]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1616,7 +1605,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1636,19 +1625,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 10 86 00 00                 # mov edi, [next_save_process_address]
+8B 3D FF 85 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1698,13 +1687,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 10 86 00 00                 # mov [next_save_process_address], edi
+89 3D FF 85 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1723,8 +1712,8 @@ AA                    # stosb
 # prepare process image in memory
 50                    # push eax                 ; save new process id
 # get file address and length
-E8 BC FC FF FF        # call absolute_path
-E8 54 FD FF FF        # call find_file           ; eax=find_file(ebx)
+E8 CD FC FF FF        # call absolute_path
+E8 65 FD FF FF        # call find_file           ; eax=find_file(ebx)
 
 # zero process memory.
 # Do this after looking up file name because that may come from process memory.
@@ -1791,7 +1780,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 7E 86 00 00           # inc [next_process_num]
+FF 05 6D 86 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1807,13 +1796,13 @@ C3                    # ret
 
 
 #----------------------------------------
-#[87BD]
+#[87AC]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
 
-E8 21 FC FF FF        # call absolute_path
-E8 B9 FC FF FF        # call find_file
+E8 32 FC FF FF        # call absolute_path
+E8 CA FC FF FF        # call find_file
 83 F8 FF              # cmp eax, -1
 74 3F                 # je chdir_finish
 
@@ -1828,7 +1817,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D 7E 86 00 00           # mov edi, [next_process_num]
+8B 3D 6D 86 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1862,11 +1851,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8810]
+#[87FF]
 #:handle_syscall_exit
-A1 7E 86 00 00        # mov eax, [next_process_num]
+A1 6D 86 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 7E 86 00 00        # mov [next_process_num], eax
+A3 6D 86 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1886,7 +1875,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 10 86 00 00                 # mov [next_save_process_address], esi
+89 35 FF 85 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1909,9 +1898,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[8864]
+#[8853]
 #:handle_syscall_waitpid
-8B 35 7E 86 00 00        # mov esi, [next_process_num]
+8B 35 6D 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1923,7 +1912,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[887E]
+#[886D]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1934,7 +1923,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 7E 86 00 00           # mov esi, [next_process_num]
+8B 35 6D 86 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1959,7 +1948,7 @@ C3                    # ret
 #:seek_end
 56                    # push esi
 53                    # push ebx
-E8 04 FC FF FF        # call fd_to_file_index
+E8 15 FC FF FF        # call fd_to_file_index
 BE 00 00 00 01        # mov esi, 0x01000000      ; pfile_descriptor = &file_descriptor[0]
 C1 E3 04              # shl ebx, 04
 01 DE                 # add esi, ebx
@@ -1975,13 +1964,13 @@ C3                    # ret
 
 
 #----------------------------------------
-#[88C4]
+#[88B3]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
 #  ecx: mode
-E8 1C FB FF FF           # call absolute_path
-E8 B4 FB FF FF           # call find_file
+E8 2D FB FF FF           # call absolute_path
+E8 C5 FB FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 74 02                    # je access_error_exit
 31 C0                    # xor eax, eax
@@ -1990,14 +1979,14 @@ C3                       # ret
 
 
 #----------------------------------------
-#[88D6]
+#[88C5]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
 #  ecx: mode
 51                             # push ecx
 B9 41 00 00 00                 # mov ecx, 0x41  (O_CREAT | O_WRONLY)
-E8 2A FA FF FF                 # call handle_syscall_open
+E8 3B FA FF FF                 # call handle_syscall_open
 83 F8 FF                       # cmp eax, -1
 74 02                          # je open_error_exit
 31 C0                          # xor eax, eax
@@ -2007,7 +1996,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[88EA]
+#[88D9]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -2018,7 +2007,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 7E 86 00 00        # mov esi, [next_process_num]
+8B 35 6D 86 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -2045,7 +2034,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8917]
+#[8906]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2079,19 +2068,19 @@ C3                    # ret
 
 
 #------
-#[8932]
+#[8921]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8934]
+#[8923]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 32 89 00 00        # mov ecx, io_char
+B9 21 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2100,7 +2089,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 32 89 00 00        # mov al, io_char
+A0 21 89 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2110,16 +2099,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8957]
+#[8946]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 32 89 00 00        # mov io_char, al
+A2 21 89 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 32 89 00 00        # mov ecx, io_char
+B9 21 89 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2131,7 +2120,7 @@ C3                    # ret
 
 
 #------
-#[8976]
+#[8965]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2145,7 +2134,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[897A]
+#[8969]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2154,8 +2143,8 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE 76 89 00 00          # mov esi, string_src
-E8 A0 F8 FF FF          # call console_puts
+BE 65 89 00 00          # mov esi, string_src
+E8 B1 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
 E8 A0 FF FF FF          # call read 'c'
@@ -2202,7 +2191,7 @@ EB F2                   # jmp get_file_name_loop
 59                      # pop ecx
 
 BE 00 00 D0 04          # mov esi, 0x04D00000
-E8 47 F8 FF FF          # call console_puts
+E8 58 F8 FF FF          # call console_puts
 
 # open filename for write
 51                      # push ecx
@@ -2238,20 +2227,20 @@ C3                      # ret
 
 
 #------
-#[8A19]
+#[8A08]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[8A1E]
+#[8A0D]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 19 8A 00 00          # mov esi, hex0_str
-E8 FF F7 FF FF          # call console_puts
+BE 08 8A 00 00          # mov esi, hex0_str
+E8 10 F8 FF FF          # call console_puts
 
 # read "ex0 '
 B1 04                   # mov cl, 4
@@ -2273,7 +2262,7 @@ B9 00 08 00 00          # mov ecx, 0x00000800
 BA 00 00 D0 04          # mov edx, 0x04D00000
 #:get_filename1_loop
 E8 E2 FE FF FF          # call read
-E8 B7 F7 FF FF          # call console_putc
+E8 C8 F7 FF FF          # call console_putc
 3C 20                   # cmp al, ' '
 74 05                   # je got_filename1
 88 02                   # mov [edx], al
@@ -2284,7 +2273,7 @@ EB ED                   # jmp get_file_name1_loop
 BA 00 04 D0 04          # mov edx, 0x04D00400
 #:get_filename2_loop
 E8 CA FE FF FF          # call read
-E8 9F F7 FF FF          # call console_putc
+E8 B0 F7 FF FF          # call console_putc
 3C 0A                   # cmp al, '\n'
 74 05                   # je got_filename2
 88 02                   # mov [edx], al
@@ -2315,7 +2304,7 @@ CD 80                   # int 80
 
 
 #------
-#[8AA5]
+#[8A94]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2405,18 +2394,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8B12]
+#[8B01]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[8B1A]
+#[8B09]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[8B1E]
+#[8B0D]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2424,7 +2413,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D A1 8B 00 00   00     # cmp [enable_flush], 0
+83 3D 90 8B 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2467,14 +2456,14 @@ EB F2                      # jmp get_argument1_loop
 
 #:got_argument1
 BE 00 00 D0 04             # mov esi, program
-E8 AD F6 FF FF             # call console_puts
+E8 BE F6 FF FF             # call console_puts
 
 BE 00 04 D0 04             # mov esi, arg1
-E8 A3 F6 FF FF             # call console_puts
+E8 B4 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 12 8B 00 00             # mov ecx, cmd_args
-BA 1A 8B 00 00             # mov edx, cmd_env
+B9 01 8B 00 00             # mov ecx, cmd_args
+BA 09 8B 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2485,27 +2474,27 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[8BA1]
+#[8B90]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[8BA5]
+#[8B94]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB 47 8C 00 00           # mov ebx, str_dev_hda
-E8 D2 F8 FF FF           # call find_file
+BB 36 8C 00 00           # mov ebx, str_dev_hda
+E8 E3 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 31 8C 00 00           # mov esi, str_error_no_write
-E8 6B F6 FF FF           # call console_puts
+BE 20 8C 00 00           # mov esi, str_error_no_write
+E8 7C F6 FF FF           # call console_puts
 
 # one space to flush last line
 B0 20                    # mov al, 20
-E8 48 F6 FF FF           # call console_putc
+E8 59 F6 FF FF           # call console_putc
 58                       # pop eax
 C3                       # ret
 
@@ -2521,11 +2510,11 @@ C1 E0 04                 # shl eax, 04
 B9 04 00 00 00           # mov ecx, 4
 #:shift_loop
 C1 C8 18                 # ror eax, 24
-E8 37 F6 FF FF           # call console_put_hex
+E8 48 F6 FF FF           # call console_put_hex
 49                       # dec ecx
 75 F5                    # jnz shift_loop
 B0 0A                    # mov al, 0A
-E8 1F F6 FF FF           # call console_putc
+E8 30 F6 FF FF           # call console_putc
 
 # set starting disk location to write
 31 C9                    # xor ecx, ecx
@@ -2533,16 +2522,16 @@ E8 1F F6 FF FF           # call console_putc
 #:sector_loop
 # copy 512 bytes from file to 16 bit buffer
 51                       # push ecx                 ; save disk location
-BF 00 A0 00 00           # mov edi, 0x000A000
+BF 00 00 04 00           # mov edi, 0x0040000
 B9 00 02 00 00           # mov ecx, 0x200
 F3 A4                    # rep movsb
 59                       # pop ecx
 
 # now write from 16 bit buffer
 56                       # push esi                 ; save our location in the file
-BE 00 A0 00 00           # mov esi, 0x000A000
+BE 00 00 00 40           # mov esi, 0x4000:0000     ; addr 0x40000
 B8 01 00 00 00           # mov eax, 0x0001          ; num_sectors = 1
-E8 43 F6 FF FF           # call write_sectors
+E8 54 F6 FF FF           # call write_sectors
 5E                       # pop esi
 
 81 EB 00 02 00 00        # sub ebx, 0x200           ; bytes_to_write -= 512
@@ -2550,38 +2539,38 @@ E8 43 F6 FF FF           # call write_sectors
 7F D9                    # jg sector_loop
 
 B0 20                    # mov al, 20
-E8 EF F5 FF FF           # call console_putc
+E8 00 F6 FF FF           # call console_putc
 58                       # pop eax
 C3                       # ret
 
 
 #------
-#[8C21]
+#[8C10]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8C31]
+#[8C20]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[8C47]
+#[8C36]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
 #------
-#[8C50]
+#[8C3F]
 #:str_e820
 #/  e  8  2  0 \0
 2F 65 38 32 30 00
 
 
 #------------------------------------------------------------
-#[8C56]
+#[8C45]
 #:internalshell
 
 # clear file name table
@@ -2596,7 +2585,7 @@ A1 00 08 01 00                 # mov eax, [0x10800]
 74 20                          # jz no_e820
 A3 38 00 00 01                 # mov [0x1000038], eax
 C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
-BE 50 8C 00 00                 # mov esi, str_e820
+BE 3F 8C 00 00                 # mov esi, str_e820
 BF 00 0C 20 00                 # mov edi, 0x200C00
 B9 06 00 00 00                 # mov ecx, 6
 F3 A4                          # rep movsb
@@ -2616,7 +2605,7 @@ C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 #:after_set_stdin
 # start at "end of sector" to trigger an initial sector read
-66 C7 05 04 00 00 01 FF 01     # mov word [0x01000004], 0x01FF
+66 C7 05 04 00 00 01 FF 7F     # mov word [0x01000004], 0x7FFF
 66 C7 05 00 01 02 00 2F 00     # mov [0x00020100], 0x002F     ; proc[0].cwd = "/"
 66 C7 05 00 11 02 00 2F 00     # mov [0x00021100], 0x002F     ; proc[1].cwd = "/"
 
@@ -2656,7 +2645,7 @@ EB E1                          # jmp process_command
 
 #:handle_flush_command
 E8 32 FC FF FF                 # call read    ; read the newline
-FF 05 A1 8B 00 00              # inc dword [enable_flush]
+FF 05 90 8B 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
@@ -2664,16 +2653,17 @@ E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 21 8C 00 00                 # mov esi, str_build_finished
-E8 0F F5 FF FF                 # call console_puts
+BE 10 8C 00 00                 # mov esi, str_build_finished
+E8 20 F5 FF FF                 # call console_puts
 
 E8 85 FE FF FF                 # call flush_disk
 
 #:shell_reboot
-E9 3B F5 FF FF                 # jmp reboot
+E9 4C F5 FF FF                 # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/builder-hex0.hex0
+++ b/builder-hex0.hex0
@@ -123,7 +123,7 @@ EA 07 7C 00 00     # jmp far setcs
 BC 00 7B           # mov sp, 0x7B00
 FC                 # cld ; clear direction flag
 
-E9 80 01           # jmp kernel_main
+E9 90 01           # jmp kernel_main
 
 
 #------------------------
@@ -257,7 +257,9 @@ C3                   # ret
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
 56                       # push si
 BE 60 7C                 # mov si, addr_packet      ; disk address packet
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 72 21                    # jc read_error
 
 8B 3E 62 7C              # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
@@ -273,7 +275,7 @@ C1 E7 09                 # shl di, 9     ; 512 == 2^9
 01 FB                    # add bx, di
 
 85 F6                    # test si, si
-75 CA                    # jnz read_one_loop
+75 C6                    # jnz read_one_loop
 
 89 DF                    # mov di, bx
 
@@ -300,13 +302,15 @@ BE 60 7C                 # mov si, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 50 7C              # mov dl, [boot_drive]
 31 C0                    # xor ax, ax
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 5E                       # pop si
-EB 96                    # jmp read_one_loop
+EB 8E                    # jmp read_one_loop
 
 
 #------------------------
-#[7CE7]
+#[7CEF]
 #:write_sectors_16
 # inputs:
 #   si: source_addr
@@ -335,7 +339,9 @@ EB 96                    # jmp read_one_loop
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
 BE 60 7C                # mov si, addr_packet      ; disk address packet
 
+66 60                   # pushad
 CD 13                   # int 0x13
+66 61                   # popad
 72 20                   # jc write_error
 
 8B 36 62 7C             # mov si, word ptr [num_sectors_bios]  ; number of sectors actually written
@@ -350,7 +356,7 @@ C1 E6 09                # shl si, 9     ; 512 == 2^9
 01 F3                   # add bx, si
 
 85 FF                   # test di, di
-75 CC                   # jnz write_one_loop
+75 C8                   # jnz write_one_loop
 
 89 DE                   # mov si, bx
 
@@ -377,8 +383,10 @@ BF 60 7C                # mov di, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 50 7C             # mov dl, [boot_drive]
 31 C0                   # xor ax, ax
+66 60                   # pushad
 CD 13                   # int 0x13
-EB 99                   # jmp write_one_loop
+66 61                   # popad
+EB 91                   # jmp write_one_loop
 
 
 # align GDT to 16 byte boundary
@@ -387,7 +395,7 @@ EB 99                   # jmp write_one_loop
 #---------------------------------------------
 # The Global Descriptor Table for 32 bit mode.
 #---------------------------------------------
-#[7D60]
+#[7D70]
 #:GDT_start
 00 00 00 00 00 00 00 00
 
@@ -436,20 +444,20 @@ FF FF # limit 0:15
 00    # base 24:31
 
 #------
-#[7D88]
+#[7D98]
 #:GDT_locator
 27 00        #  length
-60 7D 00 00  #  GDT_start
+70 7D 00 00  #  GDT_start
 
 #------
-#[7D8E]
+#[7D9E]
 #:Saved_GDT_locator
 00 00        #  length
 00 00 00 00  #  GDT_start
 
 
 #------------------------
-#[7D94]
+#[7DA4]
 #:kernel_main
 # inputs:
 #   dl: boot_drive
@@ -465,7 +473,7 @@ B8 00 7C                # mov ax, $kernel_entry
 BF 00 7E                # mov di, 0x7E00   ; place remaining code after MBR in memory
 B8 07 00                # mov ax, 7        ; num_sectors = 7
 66 B9 01 00 00 00       # mov ecx, 1       ; starting logical sector = 1
-E8 C1 FE                # call read_sectors_16
+E8 B1 FE                # call read_sectors_16
 
 #:after_load
 # check if A20 line needs handling
@@ -511,8 +519,13 @@ FB                      # sti
 1F                      # pop ds
 9D                      # popf
 
-A3 26 7F                # mov word ptr [Init_A20], ax
+A3 36 7F                # mov word ptr [Init_A20], ax
 85 C0                   # test ax, ax
+EB 03                   # jmp past_MBR
+90                      # nop    ; padding to align MBR
+# This is the DOS/MBR identifier at offset 510:
+55 AA
+#:past_MBR
 75 05                   # jnz init_no_a20
 
 # enable Gate A20
@@ -529,11 +542,6 @@ CD 15                   # int 15h
 06                          # push es
 68 00 10                    # push 0x1000
 07                          # pop es
-EB 03                       # jmp past_MBR
-90                          # nop    ; padding to align MBR
-# This is the DOS/MBR identifier at offset 510:
-55 AA
-#:past_MBR
 66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
 26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
 BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
@@ -582,15 +590,15 @@ E3 27                       # jcxz skipent              ; skip any 0 length entr
 
 # start 32bit mode
 FA                      # cli
-0F 01 06 8E 7D              # sgdt Saved_GDT_locator
-0F 01 16 88 7D          # lgdt GDT_locator
+0F 01 06 9E 7D              # sgdt Saved_GDT_locator
+0F 01 16 98 7D          # lgdt GDT_locator
 0F 20 C0                # mov eax, cr0
 66 83 C8 01             # or eax, 0x01
 0F 22 C0                # mov cr0, eax
-EA B2 7E 08 00          # jmp setup_32bit     ; sets CS
+EA C2 7E 08 00          # jmp setup_32bit     ; sets CS
 
 #------
-#[7EB2]
+#[7EC2]
 #:setup_32bit
 66 B8 10 00             # mov ax, 0x0010      ; data descriptor
 8E D8                   # mov ds, ax
@@ -606,28 +614,28 @@ E9 75 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
-#[7ED1]
+#[7EE1]
 #:setup_int_handlers
 53                        # push ebx
 
 # handle the timer interrupt 08
 BB 40 00 01 00            # mov ebx, &interrupt_table[08]
-66 C7 03 1B 7F                       # mov word [ebx + 0], low_address stub_interrupt_handler
+66 C7 03 2B 7F                       # mov word [ebx + 0], low_address stub_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # handle int 80
 BB 00 04 01 00            # mov ebx, &interrupt_table[80]
-66 C7 03 5B 80                       # mov word [ebx + 0], low_address syscall_interrupt_handler
+66 C7 03 6B 80                       # mov word [ebx + 0], low_address syscall_interrupt_handler
 66 C7 43 06 00 00         # mov word [ebx + 6], high_address
 66 C7 43 02 08 00         # mov word [ebx + 2], code_segment = 0x0800
 C6 43 05 8E               # mov byte [ebx + 5], flags = 8E
 
 # load the interrupt table
 FA                        # cli
-0F 01 1D 20 7F 00 00      # lidt IDT_locator_32
-8B 1D 1C 7F 00 00         # mov ebx, [have_userspace]
+0F 01 1D 30 7F 00 00      # lidt IDT_locator_32
+8B 1D 2C 7F 00 00         # mov ebx, [have_userspace]
 85 DB                     # test ebx
 74 01                     # jz before_userspace
 FB                        # sti
@@ -637,23 +645,23 @@ C3                        # ret
 
 
 #----------------------------------------
-#[7F1B]
+#[7F2B]
 #:stub_interrupt_handler
 CF                    # iret
 
 #----------------------------------------
-#[7F1C]
+#[7F2C]
 #:have_userspace
 00 00 00 00
 
 #----------------------------------------
-#[7F20]
+#[7F30]
 #:IDT_locator_32
 FF 07        #  length
 00 00 01 00  #  IDT_start
 
 #----------------------------------------
-#[7F26]
+#[7F36]
 #:Init_A20
 00 00
 
@@ -673,7 +681,7 @@ FF 07        #  length
 # 7B00  <- top of real mode stack
 
 #----------------------------------------
-#[7F28]
+#[7F38]
 #:enter_16bit_real
 FA                        # cli
 A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these locally
@@ -684,9 +692,9 @@ A3 08 7B 00 00            # mov [0x7B08], eax  ; preserve so we can use these lo
 # The following far jump sets CS to a 16-bit protected mode selector
 # and the segment registers are also set to 16-bit protected mode selectors.
 # This is done prior to entering real mode.
-EA 42 7F 00 00  18 00 # jmp 0x18:setup_16bit
+EA 52 7F 00 00  18 00 # jmp 0x18:setup_16bit
 #------
-#[7F42]
+#[7F52]
 #:setup_16bit
 B8 20 00                  # mov ax, 0x0020
 8E D0                     # mov ss, ax
@@ -700,9 +708,9 @@ BC 00 7B                  # mov sp, 0x7B00
 0F 22 C0                  # mov cr0, eax
 # The following far jump sets CS to a 16-bit real mode segment
 # and the segment registers are also set to real mode segments.
-EA 61 7F 00 00            # jmp 0000:XXXX  real_mode
+EA 71 7F 00 00            # jmp 0000:XXXX  real_mode
 #------
-#[7F61]
+#[7F71]
 #:real_mode
 B8 00 00                  # mov ax, 0x0
 8E D8                     # mov ds, ax
@@ -712,12 +720,12 @@ B8 00 00                  # mov ax, 0x0
 8E C0                     # mov es, ax
 BC 00 7B                  # mov sp, 0x7B00
 FA                        # cli
-0F 01 1E A0 7F            # lidt IDT_locator_16
-0F 01 16 8E 7D              # lgdt Saved_GDT_locator
+0F 01 1E B0 7F            # lidt IDT_locator_16
+0F 01 16 9E 7D              # lgdt Saved_GDT_locator
 FB                        # sti
 
 # Reset Gate A20 if needed
-A1 26 7F                  # mov ax, word ptr [Init_A20]
+A1 36 7F                  # mov ax, word ptr [Init_A20]
 85 C0                     # test ax, ax
 75 05                     # jnz enter_no_a20
 B8 00 24                  # mov ax,2400h     # disable A20 line
@@ -738,17 +746,17 @@ CB                        # retf
 00 00 00 00 00 00 00 00 00 00 00 00
 
 #------
-#[7FA0]
+#[7FB0]
 #:IDT_locator_16
 FF 03
 00 00 00 00
 
 
 #----------------------------------------
-#[7FA6]
+#[7FB6]
 #:resume_32bit_mode
 50                           # push ax
-A1 26 7F                     # mov ax, word ptr [Init_A20]
+A1 36 7F                     # mov ax, word ptr [Init_A20]
 85 C0                        # test ax, ax
 75 05                        # jnz exit_no_a20
 
@@ -763,14 +771,14 @@ A3 08 7B                     # mov [0x7B08], ax  ; preserve, they might be retur
 89 16 14 7B                  # mov [0x7B14], dx
 5A                           # pop dx      ; carry the return IP in dx
 58                           # pop ax      ; CS
-0F 01 06 8E 7D               # sgdt Saved_GDT_locator
-0F 01 16 88 7D               # lgdt GDT_locator
+0F 01 06 9E 7D               # sgdt Saved_GDT_locator
+0F 01 16 98 7D               # lgdt GDT_locator
 0F 20 C0                     # mov eax, cr0
 66 83 C8 01                  # or eax, 0x01         ; enable protected mode
 0F 22 C0                     # mov cr0, eax
-EA D7 7F 08 00               # jmp restore_32bit
+EA E7 7F 08 00               # jmp restore_32bit
 #------
-#[7FD7]
+#[7FE7]
 #:restore_32bit
 B8 10 00 00 00               # mov eax, 0x0010      ; data descriptor
 8E D8                        # mov ds, eax
@@ -791,26 +799,26 @@ C3                           # ret
 
 
 #------------------------
-#[7FFE]
+#[800E]
 #:console_putc
 #
 E8 25 FF FF FF          # call enter_16bit_real
-E8 0E FC                # call console_putc_16(al)
-9A A6 7F 00 00          # call resume_32bit_mode
+E8 FE FB                # call console_putc_16(al)
+9A B6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[800C]
+#[801C]
 #:console_put_hex
 E8 17 FF FF FF          # call enter_16bit_real
-E8 16 FC                # call console_put_hex_16(al)
-9A A6 7F 00 00          # call resume_32bit_mode
+E8 06 FC                # call console_put_hex_16(al)
+9A B6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[801A]
+#[802A]
 #:console_puts
 # inputs
 #   ds:si: string to print
@@ -832,7 +840,7 @@ C3                      # ret
 
 
 #------------------------
-#[8034]
+#[8044]
 #:read_sectors
 # inputs:
 #   di: dest_addr
@@ -840,13 +848,13 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 EF FE FF FF          # call enter_16bit_real
-E8 34 FC                # call read_sectors_16
-9A A6 7F 00 00          # call resume_32bit_mode
+E8 24 FC                # call read_sectors_16
+9A B6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 
 #------------------------
-#[8042]
+#[8052]
 #:write_sectors
 # inputs:
 #   si: source_addr
@@ -854,12 +862,12 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 E1 FE FF FF          # call enter_16bit_real
-E8 9D FC                # call write_sectors_16
-9A A6 7F 00 00          # call resume_32bit_mode
+E8 95 FC                # call write_sectors_16
+9A B6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
 #------------------------
-#[8050]
+#[8060]
 #:reboot
 E8 D3 FE FF FF          # call enter_16bit_real
 FA                      # cli
@@ -867,7 +875,7 @@ EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 
 
 #------------------------
-#[805B]
+#[806B]
 #:syscall_interrupt_handler
 #
 3C 01                             # cmp al, 1
@@ -967,17 +975,17 @@ CF                                # iret
 
 
 #------
-#[80F3]
+#[8103]
 #:next_filenum
 04 00 00 00
 
 #------
-#[80F7]
+#[8107]
 #:next_file_address
 00 00 00 54
 
 #----------------------------------------
-#[80FB]
+#[810B]
 #:handle_syscall_open
 # inputs:
 #   ebx: filename
@@ -1032,7 +1040,7 @@ E9 80 00 00 00              # jmp open_finish_fail
 # copy filename to new slot
 89 DE                       # mov esi, ebx
 BF 00 00 20 00              # mov edi, 0x0200000
-A1 F3 80 00 00              # mov eax, [next_filenum]
+A1 03 81 00 00              # mov eax, [next_filenum]
 C1 E0 0A                    # shl eax, 0a
 01 C7                       # add edi, eax
 B9 00 04 00 00              # mov ecx, 0x0000400
@@ -1040,18 +1048,18 @@ F3 A4                       # rep movsb
 
 # set address of file
 BF 00 00 00 01              # mov edi, 0x01000000           ; pfile_descriptor = &file_descriptor[0]
-A1 F3 80 00 00              # mov eax, [next_filenum]
+A1 03 81 00 00              # mov eax, [next_filenum]
 C1 E0 04                    # shl eax, 04
 01 C7                       # add edi, eax                  ; pfile_descriptor += sizeof(file_descriptor) * next_filenum
-8B 0D F7 80 00 00           # mov ecx, [next_file_address]
+8B 0D 07 81 00 00           # mov ecx, [next_file_address]
 
 89 4F 04                    # mov [edi+4], ecx              ; pfile_descriptor->file_addr = ecx
 
 31 C0                       # xor eax, eax
 89 47 08                    # mov [edi+8], eax              ; pfile_descriptor->length = 0
 
-A1 F3 80 00 00              # mov eax, [next_filenum]       ; return next_filenum
-FF 05 F3 80 00 00           # inc [next_filenum]
+A1 03 81 00 00              # mov eax, [next_filenum]       ; return next_filenum
+FF 05 03 81 00 00           # inc [next_filenum]
 EB 16                       # jmp syscall_open_finish
 
 #:open_read
@@ -1066,7 +1074,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 6E 84 00 00           # mov esi, [next_process_num]
+8B 35 7E 84 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1088,7 +1096,7 @@ EB F4                       # jmp find_slot_loop
 89 4E 04                    # mov [esi+0x4], ecx
 
 #--------
-#[81B8]
+#[81C8]
 #:open_finish_fail
 
 5F                          # pop edi
@@ -1099,13 +1107,13 @@ C3                          # ret
 
 
 #----------------------------------------
-#[81BD]
+#[81CD]
 #:handle_syscall_close
 # inputs:
 #   ebx: fd
 
 57                          # push edi
-8B 3D 6E 84 00 00           # mov edi, [next_process_num]
+8B 3D 7E 84 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1116,7 +1124,7 @@ C3                          # ret
 
 
 #----------------------------------------
-#[81D5]
+#[81E5]
 #:absolute_path
 # inputs:
 #   ebx: path
@@ -1136,7 +1144,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 6E 84 00 00             # mov esi, [next_process_num]
+8B 35 7E 84 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1253,7 +1261,7 @@ C3                            # ret
 
 
 #----------------------------------------
-#[8272]
+#[8282]
 #:find_file
 # inputs:
 #   ebx: file_name
@@ -1265,7 +1273,7 @@ C3                            # ret
 56                    # push esi
 57                    # push edi
 
-A1 F3 80 00 00        # mov eax, [next_filenum]
+A1 03 81 00 00        # mov eax, [next_filenum]
 48                    # dec eax
 89 DE                 # mov esi, ebx
 
@@ -1292,14 +1300,14 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[82A2]
+#[82B2]
 #:fd_to_file_index
 # inputs:
 #   ebx: file descriptor number
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D 6E 84 00 00        # mov edi, [next_process_num]
+8B 3D 7E 84 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1309,7 +1317,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[82B8]
+#[82C8]
 #:handle_syscall_read
 # inputs:
 #   ecx: *return_char
@@ -1386,7 +1394,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 6E 84 00 00        # mov esi, [next_process_num]
+8B 35 7E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1418,11 +1426,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8366]
+#[8376]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1457,7 +1465,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[8395]
+#[83A5]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1491,7 +1499,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D 6E 84 00 00         # mov ecx, [next_process_num]
+8B 0D 7E 84 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1518,7 +1526,7 @@ FF 01                     # inc long [ecx]       ; current_offset++
 3B 43 08                  # cmp eax, [ebx+0x8]
 7E 09                     # jle skip_lengthen
 FF 43 08                  # inc long [ebx+0x8]   ; file_length++
-FF 05 F7 80 00 00         # inc long [next_file_address]
+FF 05 07 81 00 00         # inc long [next_file_address]
 #:skip_lengthen
 58                        # pop eax
 40                        # inc eax              ; num_written++
@@ -1534,12 +1542,12 @@ C3                        # ret
 
 
 #------
-#[8400]
+#[8410]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8404]
+#[8414]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1548,7 +1556,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1561,12 +1569,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 00 84 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 10 84 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 00 84 00 00                 # add [next_save_process_address], ecx
+01 0D 10 84 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1581,7 +1589,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 00 84 00 00                 # add [next_save_process_address], ecx
+01 0D 10 84 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1595,12 +1603,12 @@ C3                    # ret
 
 
 #------
-#[846E]
+#[847E]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[8472]
+#[8482]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1608,7 +1616,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1628,19 +1636,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 00 84 00 00                 # mov edi, [next_save_process_address]
+8B 3D 10 84 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1690,13 +1698,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 00 84 00 00                 # mov [next_save_process_address], edi
+89 3D 10 84 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1783,7 +1791,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 6E 84 00 00           # inc [next_process_num]
+FF 05 7E 84 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1799,7 +1807,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[85AD]
+#[85BD]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
@@ -1820,7 +1828,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D 6E 84 00 00           # mov edi, [next_process_num]
+8B 3D 7E 84 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1854,11 +1862,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8600]
+#[8610]
 #:handle_syscall_exit
-A1 6E 84 00 00        # mov eax, [next_process_num]
+A1 7E 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 6E 84 00 00        # mov [next_process_num], eax
+A3 7E 84 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1878,7 +1886,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 00 84 00 00                 # mov [next_save_process_address], esi
+89 35 10 84 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1901,9 +1909,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[8654]
+#[8664]
 #:handle_syscall_waitpid
-8B 35 6E 84 00 00        # mov esi, [next_process_num]
+8B 35 7E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1915,7 +1923,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[866E]
+#[867E]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1926,7 +1934,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 6E 84 00 00           # mov esi, [next_process_num]
+8B 35 7E 84 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1967,7 +1975,7 @@ C3                    # ret
 
 
 #----------------------------------------
-#[86B4]
+#[86C4]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
@@ -1982,7 +1990,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[86C6]
+#[86D6]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
@@ -1999,7 +2007,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[86DA]
+#[86EA]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -2010,7 +2018,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 6E 84 00 00        # mov esi, [next_process_num]
+8B 35 7E 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -2037,7 +2045,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8707]
+#[8717]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2071,19 +2079,19 @@ C3                    # ret
 
 
 #------
-#[8722]
+#[8732]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8724]
+#[8734]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 22 87 00 00        # mov ecx, io_char
+B9 32 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2092,7 +2100,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 22 87 00 00        # mov al, io_char
+A0 32 87 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2102,16 +2110,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8747]
+#[8757]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 22 87 00 00        # mov io_char, al
+A2 32 87 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 22 87 00 00        # mov ecx, io_char
+B9 32 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2123,7 +2131,7 @@ C3                    # ret
 
 
 #------
-#[8766]
+#[8776]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2137,7 +2145,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[876A]
+#[877A]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2146,7 +2154,7 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE 66 87 00 00          # mov esi, string_src
+BE 76 87 00 00          # mov esi, string_src
 E8 A0 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
@@ -2230,19 +2238,19 @@ C3                      # ret
 
 
 #------
-#[8809]
+#[8819]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[880E]
+#[881E]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 09 88 00 00          # mov esi, hex0_str
+BE 19 88 00 00          # mov esi, hex0_str
 E8 FF F7 FF FF          # call console_puts
 
 # read "ex0 '
@@ -2307,7 +2315,7 @@ CD 80                   # int 80
 
 
 #------
-#[8895]
+#[88A5]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2397,18 +2405,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8902]
+#[8912]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[890A]
+#[891A]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[890E]
+#[891E]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2416,7 +2424,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D 91 89 00 00   00     # cmp [enable_flush], 0
+83 3D A1 89 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2435,7 +2443,7 @@ B9 FF 07 00 00             # mov ecx, 0x000007FF
 
 # no more reading from disk - enable interrupts
 40                         # inc eax
-A3 1C 7F 00 00             # mov [have_userspace], eax
+A3 2C 7F 00 00             # mov [have_userspace], eax
 FB                         # sti
 
 BA 01 00 D0 04             # mov edx, 0x04D00001
@@ -2465,8 +2473,8 @@ BE 00 04 D0 04             # mov esi, arg1
 E8 A3 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 02 89 00 00             # mov ecx, cmd_args
-BA 0A 89 00 00             # mov edx, cmd_env
+B9 12 89 00 00             # mov ecx, cmd_args
+BA 1A 89 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2477,22 +2485,22 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[8991]
+#[89A1]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[8995]
+#[89A5]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB 37 8A 00 00           # mov ebx, str_dev_hda
+BB 47 8A 00 00           # mov ebx, str_dev_hda
 E8 D2 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 21 8A 00 00           # mov esi, str_error_no_write
+BE 31 8A 00 00           # mov esi, str_error_no_write
 E8 6B F6 FF FF           # call console_puts
 
 # one space to flush last line
@@ -2548,32 +2556,32 @@ C3                       # ret
 
 
 #------
-#[8A11]
+#[8A21]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8A21]
+#[8A31]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[8A37]
+#[8A47]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
 #------
-#[8A40]
+#[8A50]
 #:str_e820
 #/  e  8  2  0 \0
 2F 65 38 32 30 00
 
 
 #------------------------------------------------------------
-#[8A46]
+#[8A56]
 #:internalshell
 
 # clear file name table
@@ -2588,7 +2596,7 @@ A1 00 08 01 00                 # mov eax, [0x10800]
 74 20                          # jz no_e820
 A3 38 00 00 01                 # mov [0x1000038], eax
 C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
-BE 40 8A 00 00                 # mov esi, str_e820
+BE 50 8A 00 00                 # mov esi, str_e820
 BF 00 0C 20 00                 # mov edi, 0x200C00
 B9 06 00 00 00                 # mov ecx, 6
 F3 A4                          # rep movsb
@@ -2648,7 +2656,7 @@ EB E1                          # jmp process_command
 
 #:handle_flush_command
 E8 32 FC FF FF                 # call read    ; read the newline
-FF 05 91 89 00 00              # inc dword [enable_flush]
+FF 05 A1 89 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
@@ -2656,7 +2664,7 @@ E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 11 8A 00 00                 # mov esi, str_build_finished
+BE 21 8A 00 00                 # mov esi, str_build_finished
 E8 0F F5 FF FF                 # call console_puts
 
 E8 85 FE FF FF                 # call flush_disk
@@ -2666,7 +2674,6 @@ E9 3B F5 FF FF                 # jmp reboot
 
 # sector padding
 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/builder-hex0.hex0
+++ b/builder-hex0.hex0
@@ -64,7 +64,7 @@
 
 #------------------------------------------------------------
 # Memory:
-# 54000000 - BFFFFFFF files (~1812MB)
+# 54000000 - BBFFFFFF files (~1744MB)
 # 30000000 - 53FFFFFF saved processes (~604MB)
 # 08048000 - 2FFFFFFF current running process (~670MB)
 # 01080000 - 08000000 32 bit stack (117MB)
@@ -75,10 +75,11 @@
 #   201800 -   FFFFFF file names 6..14335
 #   201400 -   2017FF file name 5
 #   201000 -   2013FF file name 4
-#   100000 -   200FF0 unused
-#    9FC00 -    FFFFF BIOS
-#    40200 -    9FBFF scratch buffer
-#    40000 -    401FF stdin device buffer
+#   200C00 -   200FFF file name 3 ("/e820")
+#   100000 -   200BF0 unused
+#    80000 -    FFFFF BIOS
+#    50000 -    7FFFF scratch buffer
+#    40000 -    4FFFF stdin device buffer
 #    20000 -    3FFFF process descriptors ( 16 * 4096 bytes each)
 #                      offset len    description
 #                      0x000  0x004  process address
@@ -98,8 +99,8 @@
 #                                    { global_file_index, current_offset }
 #    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
-#     A000 -     A1FF sector read buffer - 16bit
-#     7C00 -     8600 code
+#     8E00 -     FFFF unused
+#     7C00 -     8DFF code
 #     7B00 -     7BFF Saved 32 bit registers while in 16 bit mode
 #   < 7B00            real mode stack
 #------------------------------------------------------------
@@ -218,11 +219,11 @@ C3                   # ret
 #:addr_packet
 10 00
 #:num_sectors_bios
-01 00
+40 00
 #:dest_offset
 00 00
 #:dest_segment
-00 00
+00 40
 #:starting_lba
 00 00 00 00 00 00 00 00
 #:end_addr_packet
@@ -231,27 +232,24 @@ C3                   # ret
 #[7C70]
 #:read_sectors_16
 # inputs:
-#   di: dest_addr
+#   edi: dest_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   di: next byte to write to
+#   edi: next byte to write to
 #   ecx: next disk sector to read from
 #
 50                       # push ax
-53                       # push bx
+66 53                    # push ebx
 56                       # push si
 
-1E                       # push ds
-5B                       # pop bx
-89 1E 66 7C              # mov word ptr [dest_segment], bx
 89 C6                    # mov si, ax      ; si=num_sectors
-89 FB                    # mov bx, di      ; int 13 writes to bx
+66 89 FB                 # mov ebx, edi      ; int 13 writes to bx
 
 #:read_one_loop
 89 36 62 7C              # mov word ptr [num_sectors_bios], si
-89 1E 64 7C              # mov word ptr [dest_offset], bx
+66 89 1E 64 7C           # mov dword ptr [dest_offset], ebx
 66 89 0E 68 7C           # mov dword ptr [starting_lba], ecx
 8A 16 50 7C              # mov dl, [boot_drive]
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
@@ -260,27 +258,27 @@ BE 60 7C                 # mov si, addr_packet      ; disk address packet
 66 60                    # pushad
 CD 13                    # int 0x13
 66 61                    # popad
-72 21                    # jc read_error
+72 25                    # jc read_error
 
 8B 3E 62 7C              # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
 85 FF                    # test di, di
-74 19                    # jz read_error
+74 1D                    # jz read_error
 
 # we read some sectors, advance
 5E                       # pop si
 29 FE                    # sub si, di    ; num_sectors -= num_sectors_bios
 66 0F B7 C7              # movzx eax, di
 66 01 C1                 # add ecx, eax
-C1 E7 09                 # shl di, 9     ; 512 == 2^9
-01 FB                    # add bx, di
+66 C1 E0 09              # shl eax, 9    ; 512 == 2^9
+66 01 C3                 # add ebx, eax
 
 85 F6                    # test si, si
-75 C6                    # jnz read_one_loop
+75 C3                    # jnz read_one_loop
 
-89 DF                    # mov di, bx
+66 89 DF                 # mov edi, ebx
 
 5E                       # pop si
-5B                       # pop bx
+66 5B                    # pop ebx
 58                       # pop ax
 C3                       # retf
 
@@ -306,34 +304,31 @@ BE 60 7C                 # mov si, addr_packet      ; disk address packet
 CD 13                    # int 0x13
 66 61                    # popad
 5E                       # pop si
-EB 8E                    # jmp read_one_loop
+EB 89                    # jmp read_one_loop
 
 
 #------------------------
-#[7CEF]
+#[7CF0]
 #:write_sectors_16
 # inputs:
-#   si: source_addr
+#   esi: source_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   si: next byte to read from
+#   esi: next byte to read from
 #   ecx: next disk sector to write to
 #
 50                      # push ax
-53                      # push bx
+66 53                   # push ebx
 57                      # push di
 
-1E                      # push ds
-5B                      # pop bx
-89 1E 66 7C             # mov word ptr [dest_segment], bx
 89 C7                   # mov di, ax      ; di=num_sectors
-89 F3                   # mov bx, si      ; int 13 reads from [bx]
+66 89 F3                # mov ebx, esi      ; int 13 reads from [bx]
 
 #:write_one_loop
 89 3E 62 7C             # mov word ptr [num_sectors_bios], di
-89 1E 64 7C             # mov word ptr [dest_offset], bx
+66 89 1E 64 7C          # mov dword ptr [dest_offset], ebx
 66 89 0E 68 7C          # mov dword ptr [starting_lba], ecx
 8A 16 50 7C             # mov dl, [boot_drive]
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
@@ -342,26 +337,26 @@ BE 60 7C                # mov si, addr_packet      ; disk address packet
 66 60                   # pushad
 CD 13                   # int 0x13
 66 61                   # popad
-72 20                   # jc write_error
+72 24                   # jc write_error
 
 8B 36 62 7C             # mov si, word ptr [num_sectors_bios]  ; number of sectors actually written
 85 F6                   # test si, si
-74 18                   # jz write_error
+74 1C                   # jz write_error
 
 # we wrote some sectors, advance
 29 F7                   # sub di, si    ; num_sectors -= num_sectors_bios
 66 0F B7 C6             # movzx eax, si
 66 01 C1                # add ecx, eax
-C1 E6 09                # shl si, 9     ; 512 == 2^9
-01 F3                   # add bx, si
+66 C1 E0 09             # shl eax, 9    ; 512 == 2^9
+66 01 C3                # add ebx, eax
 
 85 FF                   # test di, di
-75 C8                   # jnz write_one_loop
+75 C5                   # jnz write_one_loop
 
-89 DE                   # mov si, bx
+66 89 DE                # mov esi, ebx
 
 5F                      # pop di
-5B                      # pop bx
+66 5B                   # pop ebx
 58                      # pop ax
 C3                      # retf
 
@@ -386,11 +381,11 @@ BF 60 7C                # mov di, addr_packet      ; disk address packet
 66 60                   # pushad
 CD 13                   # int 0x13
 66 61                   # popad
-EB 91                   # jmp write_one_loop
+EB 8C                   # jmp write_one_loop
 
 
 # align GDT to 16 byte boundary
-00 00 00 00 00
+00 00 00
 
 #---------------------------------------------
 # The Global Descriptor Table for 32 bit mode.
@@ -610,7 +605,7 @@ BD 00 00 00 08          # mov ebp, 0x08000000
 89 EC                   # mov esp, ebp
 
 E8 05 00 00 00          # call setup_int_handlers
-E9 75 0B 00 00          # jmp internalshell
+E9 64 0B 00 00          # jmp internalshell
 
 
 #----------------------------------------
@@ -862,7 +857,7 @@ C3                      # ret
 #   ax: num_sectors
 #
 E8 E1 FE FF FF          # call enter_16bit_real
-E8 95 FC                # call write_sectors_16
+E8 96 FC                # call write_sectors_16
 9A B6 7F 00 00          # call resume_32bit_mode
 C3                      # ret
 
@@ -880,13 +875,13 @@ EA F0 FF 00 F0          # ljmp $F000:FFF0          ; reboot
 #
 3C 01                             # cmp al, 1
 75 06                             # jne check_fork
-E8 9C 05 00 00                    # call handle_syscall_exit
+E8 8B 05 00 00                    # call handle_syscall_exit
 CF                                # iret
 
 #:check_fork
 3C 02                             # cmp al, 2
 75 06                             # jne check_read
-E8 96 03 00 00                    # call handle_syscall_fork
+E8 85 03 00 00                    # call handle_syscall_fork
 CF                                # iret
 
 #:check_read
@@ -898,7 +893,7 @@ CF                                # iret
 #:check_write
 3C 04                             # cmp al, 4
 75 06                             # jne check_open
-E8 13 03 00 00                    # call handle_syscall_write
+E8 02 03 00 00                    # call handle_syscall_write
 CF                                # iret
 
 #:check_open
@@ -916,43 +911,43 @@ CF                                # iret
 #:check_waitpid
 3C 07                             # cmp eax, 7
 75 06                             # jne check_execve
-E8 B4 05 00 00                    # call handle_syscall_waitpid
+E8 A3 05 00 00                    # call handle_syscall_waitpid
 CF                                # iret
 
 #:check_execve
 3C 0B                             # cmp eax, B
 75 06                             # jne check_chdir
-E8 C8 03 00 00                    # call handle_syscall_execve
+E8 B7 03 00 00                    # call handle_syscall_execve
 CF                                # iret
 
 #:check_chdir
 3C 0C                             # cmp al, C
 75 06                             # jne check_lseek
-E8 F9 04 00 00                    # call handle_syscall_chdir
+E8 E8 04 00 00                    # call handle_syscall_chdir
 CF                                # iret
 
 #:check_lseek
 3C 13                             # cmp al, 0x13
 75 06                             # jne check_brk
-E8 B0 05 00 00                    # call handle_syscall_lseek
+E8 9F 05 00 00                    # call handle_syscall_lseek
 CF                                # iret
 
 #:check_brk
 3C 2D                             # cmp al, 2D
 75 06                             # jne check_access
-E8 9E 02 00 00                    # call handle_syscall_brk
+E8 8D 02 00 00                    # call handle_syscall_brk
 CF                                # iret
 
 #:check_access
 3C 21                             # cmp al, 0x21
 75 06                             # jne check_mkdir
-E8 E2 05 00 00                    # call handle_syscall_access
+E8 D1 05 00 00                    # call handle_syscall_access
 CF                                # iret
 
 #:check_mkdir
 3C 27                             # cmp al, 0x27
 75 06                             # jne check_wait4
-E8 EA 05 00 00                    # call handle_syscall_mkdir
+E8 D9 05 00 00                    # call handle_syscall_mkdir
 CF                                # iret
 
 #:check_wait4
@@ -965,7 +960,7 @@ CF                                # iret
 #:check_getcwd
 3C B7                             # cmp al, 0xB7
 75 06                             # jne syscall_ok
-E8 EB 05 00 00                    # call handle_syscall_getcwd
+E8 DA 05 00 00                    # call handle_syscall_getcwd
 CF                                # iret
 
 #:syscall_ok
@@ -1074,7 +1069,7 @@ C1 E1 04                    # shl ecx, 04
 01 CE                       # add esi, ecx             ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
 #:syscall_open_finish
-8B 35 7E 84 00 00           # mov esi, [next_process_num]
+8B 35 6D 84 00 00           # mov esi, [next_process_num]
 4E                          # dec esi = current process
 C1 E6 0C                    # shl esi, 0x0C
 81 C6 20 02 02 00           # add esi, 0x0020220       ; pproc_descriptor = &pproc_descriptor[current_process_num].open_files[4]
@@ -1113,7 +1108,7 @@ C3                          # ret
 #   ebx: fd
 
 57                          # push edi
-8B 3D 7E 84 00 00           # mov edi, [next_process_num]
+8B 3D 6D 84 00 00           # mov edi, [next_process_num]
 4F                          # dec edi = current process
 C1 E7 0C                    # shl edi, 0x0C
 81 C7 00 02 02 00           # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1136,7 +1131,7 @@ C3                          # ret
 56                            # push esi
 57                            # push edi
 
-BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
+BF 00 00 05 00                # mov edi, 0x00050000      ; scratch buffer
 57                            # push edi
 
 # if absolute path, skip prefixing current directory
@@ -1144,7 +1139,7 @@ BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
 74 18                         # je strcpy_path_arg
 
 # get cwd
-8B 35 7E 84 00 00             # mov esi, [next_process_num]
+8B 35 6D 84 00 00             # mov esi, [next_process_num]
 4E                            # dec esi = current process
 C1 E6 0C                      # shl esi, 0x0C
 81 C6 00 01 02 00             # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1283,7 +1278,7 @@ A1 03 81 00 00        # mov eax, [next_filenum]
 89 C7                 # mov edi, eax
 C1 E7 0A              # shl edi, 0x0a
 81 C7 00 00 20 00     # add edi, 0x0200000
-E8 74 04 00 00        # call strcmp
+E8 63 04 00 00        # call strcmp
 74 08                 # je find_file_finish
 48                    # dec eax
 EB E6                 # jmp checkfile
@@ -1307,7 +1302,7 @@ C3                    # ret
 # outputs:
 #   ebx: global file index
 57                       # push edi
-8B 3D 7E 84 00 00        # mov edi, [next_process_num]
+8B 3D 6D 84 00 00        # mov edi, [next_process_num]
 4F                       # dec edi = current process
 C1 E7 0C                 # shl edi, 0x0C
 81 C7 00 02 02 00        # add edi, 0x00020200       ; edi = all_procs[current_process_num].open_files
@@ -1338,7 +1333,7 @@ C3                      # ret
 
 51                      # push ecx   ; we need this later to return char
 83 FB 00                # cmp ebx, 0
-75 55                   # jne read_memfile
+75 44                   # jne read_memfile
 
 # stdin disk position is stored in fd 0
 # get current position
@@ -1348,26 +1343,20 @@ BB 00 00 00 01          # mov ebx, 0x01000000
 66 8B 43 04             # mov ax, [ebx+4]
 
 #end of sector?
-66 3D FF 01             # cmp ax, 0x01ff
+66 3D FF 7F             # cmp ax, 0x7fff
 74 04                   # je read_next_sector
 
 #:nextchar
 66 40                   # inc ax
-EB 24                   # jmp getchar
+EB 13                   # jmp getchar
 
 #:read_next_sector
-BF 00 A0 00 00          # mov edi, 0x000A000
-B8 01 00 00 00          # mov eax, 0x0001   ; num_sectors = 1
+BF 00 00 00 40          # mov edi, 0x4000:0000 ; addr 0x40000
+B8 40 00 00 00          # mov eax, 0x0040   ; num_sectors = 64
 E8 44 FD FF FF          # call read_sectors
 # save new location and offset
 89 0B                   # mov [ebx], ecx
 31 C0                   # xor eax, eax
-
-# move block to device buffer
-BE 00 A0 00 00           # mov esi, 0x000A000
-BF 00 00 04 00           # mov edi, 0x0040000
-B9 00 02 00 00           # mov ecx, 0x0000200
-F3 A4                    # rep movsb
 
 #:getchar
 66 A3 04 00 00 01        # mov [0x01000004], ax
@@ -1381,7 +1370,7 @@ EB 41                    # jmp syscall_read_finish
 
 #:read_memfile
 89 D8                    # mov eax, ebx           ; eax = fd
-E8 7C FF FF FF           # call fd_to_file_index   ; ebx = global file index
+E8 8D FF FF FF           # call fd_to_file_index   ; ebx = global file index
 # get pointer to global file
 BE 00 00 00 01           # mov esi, 0x01000000    ; pfile_descriptor = &file_descriptor[0]
 C1 E3 04                 # shl ebx, 04
@@ -1394,7 +1383,7 @@ C1 E3 04                 # shl ebx, 04
 03 4E 08                 # add ecx, [esi+0x08]     ; ecx = file_address + length
 49                       # dec ecx                 ; ecx = last address to read
 
-8B 35 7E 84 00 00        # mov esi, [next_process_num]
+8B 35 6D 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 04 02 02 00        # add esi, 0x0020204
@@ -1426,11 +1415,11 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8376]
+#[8365]
 #:handle_syscall_brk
 56                    # push esi
 
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 
 BE 00 00 02 00        # mov esi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1465,7 +1454,7 @@ C3                    # ret
 
 
 #------------------------------------------------------------
-#[83A5]
+#[8394]
 #:handle_syscall_write
 # inputs:
 #   ebx: file
@@ -1487,7 +1476,7 @@ C3                    # ret
 74 57                     # jz syscall_write_finish
 50                        # push eax                ; save num_written
 8A 01                     # mov al, [ecx]
-E8 52 FC FF FF            # call console_putc
+E8 63 FC FF FF            # call console_putc
 58                        # pop eax                 ; restore num_written
 
 40                        # inc eax                 ; num_written++
@@ -1499,7 +1488,7 @@ EB EE                     # jmp std_loop
 89 CE                     # mov esi, ecx
 
 # use ecx as pointer to fd current offset
-8B 0D 7E 84 00 00         # mov ecx, [next_process_num]
+8B 0D 6D 84 00 00         # mov ecx, [next_process_num]
 49                        # dec ecx = current process
 C1 E1 0C                  # shl ecx, 0x0C
 81 C1 04 02 02 00         # add ecx, 0x0020204
@@ -1509,7 +1498,7 @@ C1 E3 03                  # shl ebx, 3
 5B                        # pop ebx
 
 # lookup global file index from file descriptor
-E8 D2 FE FF FF            # call fd_to_file_index
+E8 E3 FE FF FF            # call fd_to_file_index
 C1 E3 04                  # shl ebx, 04
 81 C3 00 00 00 01         # add ebx, 0x01000000     ; pfile_descriptor += sizeof(file_descriptor) * filenum
 
@@ -1542,12 +1531,12 @@ C3                        # ret
 
 
 #------
-#[8410]
+#[83FF]
 #:next_save_process_address
 00 00 00 30
 
 #----------------------------------------
-#[8414]
+#[8403]
 #:handle_syscall_fork
 53                    # push ebx
 51                    # push ecx
@@ -1556,7 +1545,7 @@ C3                        # ret
 57                    # push edi
 55                    # push ebp
 
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
 89 C2                 # mov edx, eax
 BF 00 00 02 00        # mov edi, 0x0020000       ; pproc_descriptor = &proc_descriptor[0]
@@ -1569,12 +1558,12 @@ C1 E0 0C              # shl eax, 0x0C
 89 77 0C              # mov [edi+0xC], esi       ; save stack pointer so we can return again later
 FF 47 10              # inc [edi+0x10]           ; fork = true
 
-A1 10 84 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
+A1 FF 83 00 00                 # mov eax, [next_save_process_address]    ; set save stack location
 89 47 24              # mov [edi+0x24], eax
 
 B9 00 00 00 08        # mov ecx, 0x08000000
 29 F1                 # sub ecx, esi             ; compute save stack length
-01 0D 10 84 00 00                 # add [next_save_process_address], ecx
+01 0D FF 83 00 00                 # add [next_save_process_address], ecx
 89 4F 28              # mov [edi+0x28], ecx
 89 C7                 # mov edi, eax
 F3 A4                 # rep movsb                ; save stack
@@ -1589,7 +1578,7 @@ C1 E0 0C              # shl eax, 0x0C
 29 F1                 # sub ecx, esi
 89 78 1C              # mov [eax+0x1C], edi     ; save address of saved process memory
 89 48 20              # mov [eax+0x20], ecx     ; save length of process memory
-01 0D 10 84 00 00                 # add [next_save_process_address], ecx
+01 0D FF 83 00 00                 # add [next_save_process_address], ecx
 F3 A4                 # rep movsb                ; copy current process image to storage
 
 31 C0                 # xor eax, eax             ; return as child, we'll return again as parent when child exits
@@ -1603,12 +1592,12 @@ C3                    # ret
 
 
 #------
-#[847E]
+#[846D]
 #:next_process_num
 01 00 00 00
 
 #----------------------------------------
-#[8482]
+#[8471]
 #:handle_syscall_execve
 # inputs:
 #   ebx: program_name
@@ -1616,7 +1605,7 @@ C3                    # ret
 #   edx: env
 #
 
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 3C 01                 # cmp al, 1
 75 0A                 # jne not_first_process
 
@@ -1636,19 +1625,19 @@ C1 E0 0C              # shl eax, 0x0C
 75 08                 # jnz forked
 
 #not_forked
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 EB 08                 # jmp prepare_stack
 
 #:forked
 FF 48 10              # dec [eax+0x10]           ; fork handled so reset: fork = false
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 
 
 #:prepare_stack
 # eax=process number to use
 # --- env ---
-8B 3D 10 84 00 00                 # mov edi, [next_save_process_address]
+8B 3D FF 83 00 00                 # mov edi, [next_save_process_address]
 6A 00                 # push 0                   ; push end of env
 #:push_env_loop
 # copy env arg to memory for this process
@@ -1698,13 +1687,13 @@ F3 A4                 # rep movsb
 50                    # push eax = argc
 
 # get current process descriptor
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax
 50                    # push eax                 ; save current process num
 C1 E0 0C              # shl eax, 0x0C
 05 00 00 02 00        # add eax, 0x0020000       ; pproc_descriptor = &proc_descriptor[current_process_num]
 
-89 3D 10 84 00 00                 # mov [next_save_process_address], edi
+89 3D FF 83 00 00                 # mov [next_save_process_address], edi
 
 # copy cwd from current process
 05 00 01 00 00        # add eax, 0x100
@@ -1723,8 +1712,8 @@ AA                    # stosb
 # prepare process image in memory
 50                    # push eax                 ; save new process id
 # get file address and length
-E8 BC FC FF FF        # call absolute_path
-E8 54 FD FF FF        # call find_file           ; eax=find_file(ebx)
+E8 CD FC FF FF        # call absolute_path
+E8 65 FD FF FF        # call find_file           ; eax=find_file(ebx)
 
 # zero process memory.
 # Do this after looking up file name because that may come from process memory.
@@ -1791,7 +1780,7 @@ F3 AA                 # rep stosb
 74 06                 # jz after_new_process
 
 # prepare for next process
-FF 05 7E 84 00 00           # inc [next_process_num]
+FF 05 6D 84 00 00           # inc [next_process_num]
 
 #:after_new_process
 # get entry point and jump
@@ -1807,13 +1796,13 @@ C3                    # ret
 
 
 #----------------------------------------
-#[85BD]
+#[85AC]
 #:handle_syscall_chdir
 56                    # push esi
 57                    # push edi
 
-E8 21 FC FF FF        # call absolute_path
-E8 B9 FC FF FF        # call find_file
+E8 32 FC FF FF        # call absolute_path
+E8 CA FC FF FF        # call find_file
 83 F8 FF              # cmp eax, -1
 74 3F                 # je chdir_finish
 
@@ -1828,7 +1817,7 @@ EB 2B                 # jmp chdir_finish
 
 #:chdir_ok
 89 DE                 # mov esi, ebx
-8B 3D 7E 84 00 00           # mov edi, [next_process_num]
+8B 3D 6D 84 00 00           # mov edi, [next_process_num]
 4F                    # dec edi = current process
 C1 E7 0C              # shl edi, 0x0C
 81 C7 00 01 02 00     # add edi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -1862,11 +1851,11 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8610]
+#[85FF]
 #:handle_syscall_exit
-A1 7E 84 00 00        # mov eax, [next_process_num]
+A1 6D 84 00 00        # mov eax, [next_process_num]
 48                    # dec eax = current process
-A3 7E 84 00 00        # mov [next_process_num], eax
+A3 6D 84 00 00        # mov [next_process_num], eax
 48                    # dec eax = parent process
 
 3C 00                 # cmp al, 0
@@ -1886,7 +1875,7 @@ C1 E0 0C              # shl eax, 0x0C
 F3 A4                 # rep movsb
 
 8B 70 24              # mov esi, [eax+0x24]                 ; deallocate memory for saved process
-89 35 10 84 00 00                 # mov [next_save_process_address], esi
+89 35 FF 83 00 00                 # mov [next_save_process_address], esi
 
 8B 60 0C              # mov esp, [eax+0xc]       ; restore stack pointer
 8B 70 14              # mov esi, [eax+0x14]      ; restore brk pointer
@@ -1909,9 +1898,9 @@ C3                    # ret                    ; go back to parent
 
 
 #----------------------------------------
-#[8664]
+#[8653]
 #:handle_syscall_waitpid
-8B 35 7E 84 00 00        # mov esi, [next_process_num]
+8B 35 6D 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 18 00 02 00        # add esi, 0x00020018      ; pchild_code = &pproc_descriptor[current_process_num].child_exit_code
@@ -1923,7 +1912,7 @@ C3                       # ret
 
 
 #----------------------------------------
-#[867E]
+#[866D]
 #:handle_syscall_lseek
 # inputs:
 #     ebx: fd
@@ -1934,7 +1923,7 @@ C3                       # ret
 #
 56                    # push esi
 
-8B 35 7E 84 00 00           # mov esi, [next_process_num]
+8B 35 6D 84 00 00           # mov esi, [next_process_num]
 4E                    # dec esi = current process
 C1 E6 0C              # shl esi, 0x0C
 81 C6 04 02 02 00     # add esi, 0x0020204       ; pproc_descriptor = &pproc_descriptor[current_process_num].files[0].offset
@@ -1959,7 +1948,7 @@ C3                    # ret
 #:seek_end
 56                    # push esi
 53                    # push ebx
-E8 04 FC FF FF        # call fd_to_file_index
+E8 15 FC FF FF        # call fd_to_file_index
 BE 00 00 00 01        # mov esi, 0x01000000      ; pfile_descriptor = &file_descriptor[0]
 C1 E3 04              # shl ebx, 04
 01 DE                 # add esi, ebx
@@ -1975,13 +1964,13 @@ C3                    # ret
 
 
 #----------------------------------------
-#[86C4]
+#[86B3]
 #:handle_syscall_access
 #inputs:
 #  ebx: path
 #  ecx: mode
-E8 1C FB FF FF           # call absolute_path
-E8 B4 FB FF FF           # call find_file
+E8 2D FB FF FF           # call absolute_path
+E8 C5 FB FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 74 02                    # je access_error_exit
 31 C0                    # xor eax, eax
@@ -1990,14 +1979,14 @@ C3                       # ret
 
 
 #----------------------------------------
-#[86D6]
+#[86C5]
 #:handle_syscall_mkdir
 #inputs:
 #  ebx: path
 #  ecx: mode
 51                             # push ecx
 B9 41 00 00 00                 # mov ecx, 0x41  (O_CREAT | O_WRONLY)
-E8 2A FA FF FF                 # call handle_syscall_open
+E8 3B FA FF FF                 # call handle_syscall_open
 83 F8 FF                       # cmp eax, -1
 74 02                          # je open_error_exit
 31 C0                          # xor eax, eax
@@ -2007,7 +1996,7 @@ C3                             # ret
 
 
 #----------------------------------------
-#[86EA]
+#[86D9]
 #:handle_syscall_getcwd
 #inputs:
 #  ebx: buf
@@ -2018,7 +2007,7 @@ C3                             # ret
 57                       # push edi
 
 89 DF                    # mov edi, ebx
-8B 35 7E 84 00 00        # mov esi, [next_process_num]
+8B 35 6D 84 00 00        # mov esi, [next_process_num]
 4E                       # dec esi = current process
 C1 E6 0C                 # shl esi, 0x0C
 81 C6 00 01 02 00        # add esi, 0x0020100       ; pproc_descriptor = &pproc_descriptor[current_process_num].current_dir
@@ -2045,7 +2034,7 @@ C3                       # ret
 
 
 #------------------------------------------------------------
-#[8717]
+#[8706]
 #:strcmp
 # inputs:
 #   esi: string1
@@ -2079,19 +2068,19 @@ C3                    # ret
 
 
 #------
-#[8732]
+#[8721]
 #:io_char
 00
 00  # free
 
 #----------------------------------------
-#[8734]
+#[8723]
 #:read
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 B8 03 00 00 00        # mov eax, 3   ; syscall=read
-B9 32 87 00 00        # mov ecx, io_char
+B9 21 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1
 
 CD 80                 # int 80 syscall
@@ -2100,7 +2089,7 @@ CD 80                 # int 80 syscall
 74 07                 # je read_finish
 
 B4 01                 # mov ah, 1
-A0 32 87 00 00        # mov al, io_char
+A0 21 87 00 00        # mov al, io_char
 
 #:read_finish
 5A                    # pop edx
@@ -2110,16 +2099,16 @@ C3                    # ret
 
 
 #----------------------------------------
-#[8757]
+#[8746]
 #:write
 50                    # push eax
 53                    # push ebx
 51                    # push ecx
 52                    # push edx
 
-A2 32 87 00 00        # mov io_char, al
+A2 21 87 00 00        # mov io_char, al
 B8 04 00 00 00        # mov eax, 4   ; syscall=write
-B9 32 87 00 00        # mov ecx, io_char
+B9 21 87 00 00        # mov ecx, io_char
 BA 01 00 00 00        # mov edx, 1   1 byte characters
 CD 80                 # int 80 syscall
 
@@ -2131,7 +2120,7 @@ C3                    # ret
 
 
 #------
-#[8776]
+#[8765]
 #:string_src
 #s  r  c \0
 73 72 63 00
@@ -2145,7 +2134,7 @@ C3                    # ret
 # Read a newline.
 # Then, read N bytes from stdin and write to the new file.
 #----------------------------------------
-#[877A]
+#[8769]
 #:src
 50                      # push eax
 53                      # push ebx
@@ -2154,8 +2143,8 @@ C3                    # ret
 56                      # push esi
 57                      # push edi
 
-BE 76 87 00 00          # mov esi, string_src
-E8 A0 F8 FF FF          # call console_puts
+BE 65 87 00 00          # mov esi, string_src
+E8 B1 F8 FF FF          # call console_puts
 
 E8 A5 FF FF FF          # call read 'r'
 E8 A0 FF FF FF          # call read 'c'
@@ -2202,7 +2191,7 @@ EB F2                   # jmp get_file_name_loop
 59                      # pop ecx
 
 BE 00 00 D0 04          # mov esi, 0x04D00000
-E8 47 F8 FF FF          # call console_puts
+E8 58 F8 FF FF          # call console_puts
 
 # open filename for write
 51                      # push ecx
@@ -2238,20 +2227,20 @@ C3                      # ret
 
 
 #------
-#[8819]
+#[8808]
 #:hex0_str
 #h  e  x  0 \0
 68 65 78 30 00
 
 #------------------------------------------------------------
-#[881E]
+#[880D]
 #:hex0
 53                      # push ebx
 56                      # push esi
 57                      # push edi
 
-BE 19 88 00 00          # mov esi, hex0_str
-E8 FF F7 FF FF          # call console_puts
+BE 08 88 00 00          # mov esi, hex0_str
+E8 10 F8 FF FF          # call console_puts
 
 # read "ex0 '
 B1 04                   # mov cl, 4
@@ -2273,7 +2262,7 @@ B9 00 08 00 00          # mov ecx, 0x00000800
 BA 00 00 D0 04          # mov edx, 0x04D00000
 #:get_filename1_loop
 E8 E2 FE FF FF          # call read
-E8 B7 F7 FF FF          # call console_putc
+E8 C8 F7 FF FF          # call console_putc
 3C 20                   # cmp al, ' '
 74 05                   # je got_filename1
 88 02                   # mov [edx], al
@@ -2284,7 +2273,7 @@ EB ED                   # jmp get_file_name1_loop
 BA 00 04 D0 04          # mov edx, 0x04D00400
 #:get_filename2_loop
 E8 CA FE FF FF          # call read
-E8 9F F7 FF FF          # call console_putc
+E8 B0 F7 FF FF          # call console_putc
 3C 0A                   # cmp al, '\n'
 74 05                   # je got_filename2
 88 02                   # mov [edx], al
@@ -2315,7 +2304,7 @@ CD 80                   # int 80
 
 
 #------
-#[88A5]
+#[8894]
 #:hex0_read_loop
 53                      # push ebx
 89 CB                   # mov ebx, ecx
@@ -2405,18 +2394,18 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 
 
 #------
-#[8912]
+#[8901]
 #:cmd_args
 00 00 D0 04
 00 04 D0 04
 
 #------
-#[891A]
+#[8909]
 #:cmd_env
 00 00 00 00
 
 #------------------------------------------------------------
-#[891E]
+#[890D]
 #:handle_other_command
 50                         # push eax
 53                         # push ebx
@@ -2424,7 +2413,7 @@ E9 93 FF FF FF          # jmp hex0_read_loop
 52                         # push edx
 56                         # push esi
 
-83 3D A1 89 00 00   00     # cmp [enable_flush], 0
+83 3D 90 89 00 00   00     # cmp [enable_flush], 0
 74 05                      # je clear_args
 E8 74 00 00 00             # call flush_disk
 
@@ -2467,14 +2456,14 @@ EB F2                      # jmp get_argument1_loop
 
 #:got_argument1
 BE 00 00 D0 04             # mov esi, program
-E8 AD F6 FF FF             # call console_puts
+E8 BE F6 FF FF             # call console_puts
 
 BE 00 04 D0 04             # mov esi, arg1
-E8 A3 F6 FF FF             # call console_puts
+E8 B4 F6 FF FF             # call console_puts
 
 BB 00 00 D0 04             # mov ebx, program_name
-B9 12 89 00 00             # mov ecx, cmd_args
-BA 1A 89 00 00             # mov edx, cmd_env
+B9 01 89 00 00             # mov ecx, cmd_args
+BA 09 89 00 00             # mov edx, cmd_env
 E8 E7 FA FF FF             # call handle_syscall_execve
 
 5E                         # pop esi
@@ -2485,27 +2474,27 @@ E8 E7 FA FF FF             # call handle_syscall_execve
 C3                         # ret
 
 #------
-#[89A1]
+#[8990]
 #:enable_flush
 00 00 00 00
 
 #------------------------------------------------------------
-#[89A5]
+#[8994]
 #:flush_disk
 50                       # push eax
 # copy memory file /dev/hda to the boot disk
-BB 47 8A 00 00           # mov ebx, str_dev_hda
-E8 D2 F8 FF FF           # call find_file
+BB 36 8A 00 00           # mov ebx, str_dev_hda
+E8 E3 F8 FF FF           # call find_file
 83 F8 FF                 # cmp eax, -1
 75 13                    # jne ok_flush
 
 #:error_exit
-BE 31 8A 00 00           # mov esi, str_error_no_write
-E8 6B F6 FF FF           # call console_puts
+BE 20 8A 00 00           # mov esi, str_error_no_write
+E8 7C F6 FF FF           # call console_puts
 
 # one space to flush last line
 B0 20                    # mov al, 20
-E8 48 F6 FF FF           # call console_putc
+E8 59 F6 FF FF           # call console_putc
 58                       # pop eax
 C3                       # ret
 
@@ -2521,11 +2510,11 @@ C1 E0 04                 # shl eax, 04
 B9 04 00 00 00           # mov ecx, 4
 #:shift_loop
 C1 C8 18                 # ror eax, 24
-E8 37 F6 FF FF           # call console_put_hex
+E8 48 F6 FF FF           # call console_put_hex
 49                       # dec ecx
 75 F5                    # jnz shift_loop
 B0 0A                    # mov al, 0A
-E8 1F F6 FF FF           # call console_putc
+E8 30 F6 FF FF           # call console_putc
 
 # set starting disk location to write
 31 C9                    # xor ecx, ecx
@@ -2533,16 +2522,16 @@ E8 1F F6 FF FF           # call console_putc
 #:sector_loop
 # copy 512 bytes from file to 16 bit buffer
 51                       # push ecx                 ; save disk location
-BF 00 A0 00 00           # mov edi, 0x000A000
+BF 00 00 04 00           # mov edi, 0x0040000
 B9 00 02 00 00           # mov ecx, 0x200
 F3 A4                    # rep movsb
 59                       # pop ecx
 
 # now write from 16 bit buffer
 56                       # push esi                 ; save our location in the file
-BE 00 A0 00 00           # mov esi, 0x000A000
+BE 00 00 00 40           # mov esi, 0x4000:0000     ; addr 0x40000
 B8 01 00 00 00           # mov eax, 0x0001          ; num_sectors = 1
-E8 43 F6 FF FF           # call write_sectors
+E8 54 F6 FF FF           # call write_sectors
 5E                       # pop esi
 
 81 EB 00 02 00 00        # sub ebx, 0x200           ; bytes_to_write -= 512
@@ -2550,38 +2539,38 @@ E8 43 F6 FF FF           # call write_sectors
 7F D9                    # jg sector_loop
 
 B0 20                    # mov al, 20
-E8 EF F5 FF FF           # call console_putc
+E8 00 F6 FF FF           # call console_putc
 58                       # pop eax
 C3                       # ret
 
 
 #------
-#[8A21]
+#[8A10]
 #:str_build_finished
 #B  u  i  l  d     f  i  n  i  s  h  e  d  . \0
 42 75 69 6C 64 20 66 69 6E 69 73 68 65 64 2E 00
 
 #------
-#[8A31]
+#[8A20]
 #:str_error_no_writes
 #E  R  R  O  R  :     n  o     h  d  a     w  r  i  t  e  s  ! \0
 45 52 52 4F 52 3A 20 6E 6F 20 68 64 61 20 77 72 69 74 65 73 21 00
 
 #------
-#[8A47]
+#[8A36]
 #:str_dev_hda
 #/  d  e  v  /  h  d  a \0
 2F 64 65 76 2F 68 64 61 00
 
 #------
-#[8A50]
+#[8A3F]
 #:str_e820
 #/  e  8  2  0 \0
 2F 65 38 32 30 00
 
 
 #------------------------------------------------------------
-#[8A56]
+#[8A45]
 #:internalshell
 
 # clear file name table
@@ -2596,7 +2585,7 @@ A1 00 08 01 00                 # mov eax, [0x10800]
 74 20                          # jz no_e820
 A3 38 00 00 01                 # mov [0x1000038], eax
 C7 05 34 00 00 01 04 08 01 00  # mov dword [0x1000034], 0x10804
-BE 50 8A 00 00                 # mov esi, str_e820
+BE 3F 8A 00 00                 # mov esi, str_e820
 BF 00 0C 20 00                 # mov edi, 0x200C00
 B9 06 00 00 00                 # mov ecx, 6
 F3 A4                          # rep movsb
@@ -2616,7 +2605,7 @@ C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 #:after_set_stdin
 # start at "end of sector" to trigger an initial sector read
-66 C7 05 04 00 00 01 FF 01     # mov word [0x01000004], 0x01FF
+66 C7 05 04 00 00 01 FF 7F     # mov word [0x01000004], 0x7FFF
 66 C7 05 00 01 02 00 2F 00     # mov [0x00020100], 0x002F     ; proc[0].cwd = "/"
 66 C7 05 00 11 02 00 2F 00     # mov [0x00021100], 0x002F     ; proc[1].cwd = "/"
 
@@ -2656,7 +2645,7 @@ EB E1                          # jmp process_command
 
 #:handle_flush_command
 E8 32 FC FF FF                 # call read    ; read the newline
-FF 05 A1 89 00 00              # inc dword [enable_flush]
+FF 05 90 89 00 00              # inc dword [enable_flush]
 EB D0                          # jmp process_command
 
 #:call_handle_other_command
@@ -2664,16 +2653,17 @@ E8 0F FE FF FF                 # call handle_other_command
 EB C9                          # jmp process_command
 
 #:build_finished
-BE 21 8A 00 00                 # mov esi, str_build_finished
-E8 0F F5 FF FF                 # call console_puts
+BE 10 8A 00 00                 # mov esi, str_build_finished
+E8 20 F5 FF FF                 # call console_puts
 
 E8 85 FE FF FF                 # call flush_disk
 
 #:shell_reboot
-E9 3B F5 FF FF                 # jmp reboot
+E9 4C F5 FF FF                 # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/builder-hex0.hex2
+++ b/builder-hex0.hex2
@@ -64,7 +64,7 @@
 
 #------------------------------------------------------------
 # Memory:
-# 54000000 - BFFFFFFF files (~1812MB)
+# 54000000 - BBFFFFFF files (~1744MB)
 # 30000000 - 53FFFFFF saved processes (~604MB)
 # 08048000 - 2FFFFFFF current running process (~670MB)
 # 01080000 - 08000000 32 bit stack (117MB)
@@ -75,10 +75,11 @@
 #   201800 -   FFFFFF file names 6..14335
 #   201400 -   2017FF file name 5
 #   201000 -   2013FF file name 4
-#   100000 -   200FF0 unused
-#    9FC00 -    FFFFF BIOS
-#    40200 -    9FBFF scratch buffer
-#    40000 -    401FF stdin device buffer
+#   200C00 -   200FFF file name 3 ("/e820")
+#   100000 -   200BF0 unused
+#    80000 -    FFFFF BIOS
+#    50000 -    7FFFF scratch buffer
+#    40000 -    4FFFF stdin device buffer
 #    20000 -    3FFFF process descriptors ( 16 * 4096 bytes each)
 #                      offset len    description
 #                      0x000  0x004  process address
@@ -98,8 +99,8 @@
 #                                    { global_file_index, current_offset }
 #    10800 -    1FFFF BIOS memory map
 #    10000 -    107FF interrupt table
-#     A000 -     A1FF sector read buffer - 16bit
-#     7C00 -     8600 code
+#     8E00 -     FFFF unused
+#     7C00 -     8DFF code
 #     7B00 -     7BFF Saved 32 bit registers while in 16 bit mode
 #   < 7B00            real mode stack
 #------------------------------------------------------------
@@ -213,11 +214,11 @@ C3                   # ret
 :addr_packet
 10 00
 :num_sectors_bios
-01 00
+40 00
 :dest_offset
 00 00
 :dest_segment
-00 00
+00 40
 :starting_lba
 00 00 00 00 00 00 00 00
 :end_addr_packet
@@ -225,27 +226,24 @@ C3                   # ret
 #------------------------
 :read_sectors_16
 # inputs:
-#   di: dest_addr
+#   edi: dest_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   di: next byte to write to
+#   edi: next byte to write to
 #   ecx: next disk sector to read from
 #
 50                       # push ax
-53                       # push bx
+66 53                    # push ebx
 56                       # push si
 
-1E                       # push ds
-5B                       # pop bx
-89 1E $dest_segment      # mov word ptr [dest_segment], bx
 89 C6                    # mov si, ax      ; si=num_sectors
-89 FB                    # mov bx, di      ; int 13 writes to bx
+66 89 FB                 # mov ebx, edi      ; int 13 writes to bx
 
 :read_one_loop
 89 36 $num_sectors_bios  # mov word ptr [num_sectors_bios], si
-89 1E $dest_offset       # mov word ptr [dest_offset], bx
+66 89 1E $dest_offset    # mov dword ptr [dest_offset], ebx
 66 89 0E $starting_lba   # mov dword ptr [starting_lba], ecx
 8A 16 $boot_drive        # mov dl, [boot_drive]
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
@@ -265,16 +263,16 @@ CD 13                    # int 0x13
 29 FE                    # sub si, di    ; num_sectors -= num_sectors_bios
 66 0F B7 C7              # movzx eax, di
 66 01 C1                 # add ecx, eax
-C1 E7 09                 # shl di, 9     ; 512 == 2^9
-01 FB                    # add bx, di
+66 C1 E0 09              # shl eax, 9    ; 512 == 2^9
+66 01 C3                 # add ebx, eax
 
 85 F6                    # test si, si
 75 !read_one_loop        # jnz read_one_loop
 
-89 DF                    # mov di, bx
+66 89 DF                 # mov edi, ebx
 
 5E                       # pop si
-5B                       # pop bx
+66 5B                    # pop ebx
 58                       # pop ax
 C3                       # retf
 
@@ -306,27 +304,24 @@ EB !read_one_loop        # jmp read_one_loop
 #------------------------
 :write_sectors_16
 # inputs:
-#   si: source_addr
+#   esi: source_addr (with segment)
 #   ecx: first logical sector
 #   ax: num_sectors
 #
 # outputs:
-#   si: next byte to read from
+#   esi: next byte to read from
 #   ecx: next disk sector to write to
 #
 50                      # push ax
-53                      # push bx
+66 53                   # push ebx
 57                      # push di
 
-1E                      # push ds
-5B                      # pop bx
-89 1E $dest_segment     # mov word ptr [dest_segment], bx
 89 C7                   # mov di, ax      ; di=num_sectors
-89 F3                   # mov bx, si      ; int 13 reads from [bx]
+66 89 F3                # mov ebx, esi      ; int 13 reads from [bx]
 
 :write_one_loop
 89 3E $num_sectors_bios # mov word ptr [num_sectors_bios], di
-89 1E $dest_offset      # mov word ptr [dest_offset], bx
+66 89 1E $dest_offset   # mov dword ptr [dest_offset], ebx
 66 89 0E $starting_lba  # mov dword ptr [starting_lba], ecx
 8A 16 $boot_drive       # mov dl, [boot_drive]
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
@@ -345,16 +340,16 @@ CD 13                   # int 0x13
 29 F7                   # sub di, si    ; num_sectors -= num_sectors_bios
 66 0F B7 C6             # movzx eax, si
 66 01 C1                # add ecx, eax
-C1 E6 09                # shl si, 9     ; 512 == 2^9
-01 F3                   # add bx, si
+66 C1 E0 09             # shl eax, 9    ; 512 == 2^9
+66 01 C3                # add ebx, eax
 
 85 FF                   # test di, di
 75 !write_one_loop      # jnz write_one_loop
 
-89 DE                   # mov si, bx
+66 89 DE                # mov esi, ebx
 
 5F                      # pop di
-5B                      # pop bx
+66 5B                   # pop ebx
 58                      # pop ax
 C3                      # retf
 
@@ -383,7 +378,7 @@ EB !write_one_loop      # jmp write_one_loop
 
 
 # align GDT to 16 byte boundary
-00 00 00 00 00
+00 00 00
 
 #---------------------------------------------
 # The Global Descriptor Table for 32 bit mode.
@@ -1100,7 +1095,7 @@ C3                          # ret
 56                            # push esi
 57                            # push edi
 
-BF 00 02 04 00                # mov edi, 0x00040200      ; scratch buffer
+BF 00 00 05 00                # mov edi, 0x00050000      ; scratch buffer
 57                            # push edi
 
 # if absolute path, skip prefixing current directory
@@ -1309,7 +1304,7 @@ BB 00 00 00 01          # mov ebx, 0x01000000
 66 8B 43 04             # mov ax, [ebx+4]
 
 #end of sector?
-66 3D FF 01             # cmp ax, 0x01ff
+66 3D FF 7F             # cmp ax, 0x7fff
 74 !read_next_sector    # je read_next_sector
 
 :nextchar
@@ -1317,18 +1312,12 @@ BB 00 00 00 01          # mov ebx, 0x01000000
 EB !getchar             # jmp getchar
 
 :read_next_sector
-BF 00 A0 00 00          # mov edi, 0x000A000
-B8 01 00 00 00          # mov eax, 0x0001   ; num_sectors = 1
+BF 00 00 00 40          # mov edi, 0x4000:0000 ; addr 0x40000
+B8 40 00 00 00          # mov eax, 0x0040   ; num_sectors = 64
 E8 %read_sectors        # call read_sectors
 # save new location and offset
 89 0B                   # mov [ebx], ecx
 31 C0                   # xor eax, eax
-
-# move block to device buffer
-BE 00 A0 00 00           # mov esi, 0x000A000
-BF 00 00 04 00           # mov edi, 0x0040000
-B9 00 02 00 00           # mov ecx, 0x0000200
-F3 A4                    # rep movsb
 
 :getchar
 66 A3 04 00 00 01        # mov [0x01000004], ax
@@ -2467,14 +2456,14 @@ E8 %console_putc         # call console_putc
 :sector_loop
 # copy 512 bytes from file to 16 bit buffer
 51                       # push ecx                 ; save disk location
-BF 00 A0 00 00           # mov edi, 0x000A000
+BF 00 00 04 00           # mov edi, 0x0040000
 B9 00 02 00 00           # mov ecx, 0x200
 F3 A4                    # rep movsb
 59                       # pop ecx
 
 # now write from 16 bit buffer
 56                       # push esi                 ; save our location in the file
-BE 00 A0 00 00           # mov esi, 0x000A000
+BE 00 00 00 40           # mov esi, 0x4000:0000     ; addr 0x40000
 B8 01 00 00 00           # mov eax, 0x0001          ; num_sectors = 1
 E8 %write_sectors        # call write_sectors
 5E                       # pop esi
@@ -2545,7 +2534,7 @@ C7 05 00 00 00 01 AF 00 00 00  # mov word [0x01000000], 0x000000AF
 
 :after_set_stdin
 # start at "end of sector" to trigger an initial sector read
-66 C7 05 04 00 00 01 FF 01     # mov word [0x01000004], 0x01FF
+66 C7 05 04 00 00 01 FF 7F     # mov word [0x01000004], 0x7FFF
 66 C7 05 00 01 02 00 2F 00     # mov [0x00020100], 0x002F     ; proc[0].cwd = "/"
 66 C7 05 00 11 02 00 2F 00     # mov [0x00021100], 0x002F     ; proc[1].cwd = "/"
 
@@ -2602,7 +2591,8 @@ E8 %flush_disk                 # call flush_disk
 E9 %reboot                     # jmp reboot
 
 # sector padding
-00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00
+00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/builder-hex0.hex2
+++ b/builder-hex0.hex2
@@ -251,7 +251,9 @@ C3                   # ret
 B4 42                    # mov ah, 0x42        ; rw mode = 42 (read LBA)
 56                       # push si
 BE $addr_packet          # mov si, addr_packet      ; disk address packet
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 72 !read_error           # jc read_error
 
 8B 3E $num_sectors_bios  # mov di, word ptr [num_sectors_bios]  ; number of sectors actually read
@@ -294,7 +296,9 @@ BE $addr_packet          # mov si, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 $boot_drive        # mov dl, [boot_drive]
 31 C0                    # xor ax, ax
+66 60                    # pushad
 CD 13                    # int 0x13
+66 61                    # popad
 5E                       # pop si
 EB !read_one_loop        # jmp read_one_loop
 
@@ -328,7 +332,9 @@ EB !read_one_loop        # jmp read_one_loop
 B4 43                   # mov ah, 0x43       ; rw mode = 43 (write LBA)
 BE $addr_packet         # mov si, addr_packet      ; disk address packet
 
+66 60                   # pushad
 CD 13                   # int 0x13
+66 61                   # popad
 72 !write_error         # jc write_error
 
 8B 36 $num_sectors_bios # mov si, word ptr [num_sectors_bios]  ; number of sectors actually written
@@ -370,7 +376,9 @@ BF $addr_packet         # mov di, addr_packet      ; disk address packet
 # Reset the disk subsystem, then try again
 8A 16 $boot_drive       # mov dl, [boot_drive]
 31 C0                   # xor ax, ax
+66 60                   # pushad
 CD 13                   # int 0x13
+66 61                   # popad
 EB !write_one_loop      # jmp write_one_loop
 
 
@@ -502,6 +510,11 @@ FB                      # sti
 
 A3 $Init_A20            # mov word ptr [Init_A20], ax
 85 C0                   # test ax, ax
+EB !past_MBR            # jmp past_MBR
+90                      # nop    ; padding to align MBR
+# This is the DOS/MBR identifier at offset 510:
+55 AA
+:past_MBR
 75 !init_no_a20         # jnz init_no_a20
 
 # enable Gate A20
@@ -518,11 +531,6 @@ CD 15                   # int 15h
 06                          # push es
 68 00 10                    # push 0x1000
 07                          # pop es
-EB !past_MBR                # jmp past_MBR
-90                          # nop    ; padding to align MBR
-# This is the DOS/MBR identifier at offset 510:
-55 AA
-:past_MBR
 66 31 DB                    # xor ebx, ebx              ; ebx must be 0 to start
 26 66 89 1E 00 08           # mov dword ptr es:[0x800], ebx ; mark structure as invalid initially
 BF 08 08                    # mov di, 0x808             ; write entries from 0x10808 for a final multiboot structure at 0x10804
@@ -2595,7 +2603,6 @@ E9 %reboot                     # jmp reboot
 
 # sector padding
 00 00 00 00 00 00 00 00 00 00 00
-00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 
 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00

--- a/hex2tohex0.py
+++ b/hex2tohex0.py
@@ -13,7 +13,7 @@ def main():
             print("ERROR: label %s not aligned to 16 byte boundary (%x)!" % (label, labels[label]))
             sys.exit(1)
     if 'past_MBR' in labels and labels['past_MBR'] != 0x7e00 and labels['past_MBR'] != 0x8000:
-            print("ERROR: label past_MBR is not 0x7e00 or 0x8000")
+            print("ERROR: label past_MBR is not 0x7e00 or 0x8000 (%x)" % labels['past_MBR'])
             sys.exit(1)
 
 


### PR DESCRIPTION
This is especially noticeable on USB drives, where the srcfs time is improved from 2 hours to a few minutes.

Depends on #13 